### PR TITLE
feat: store SCIM user/group creation/update/deletion events

### DIFF
--- a/src/main/java/fi/metatavu/keycloak/scim/server/adminEvents/AdminEventController.java
+++ b/src/main/java/fi/metatavu/keycloak/scim/server/adminEvents/AdminEventController.java
@@ -1,0 +1,108 @@
+package fi.metatavu.keycloak.scim.server.adminEvents;
+
+import fi.metatavu.keycloak.scim.server.AbstractController;
+import fi.metatavu.keycloak.scim.server.ScimContext;
+import org.keycloak.events.EventListenerProvider;
+import org.keycloak.events.EventListenerProviderFactory;
+import org.keycloak.events.EventStoreProvider;
+import org.keycloak.events.admin.AdminEvent;
+import org.keycloak.events.admin.AuthDetails;
+import org.keycloak.events.admin.OperationType;
+import org.keycloak.events.admin.ResourceType;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.util.JsonSerialization;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+public class AdminEventController extends AbstractController {
+    /**
+     * Sends an admin event
+     *
+     * @param scimContext SCIM context
+     * @param operationType operation type
+     * @param resourceType resource type
+     * @param resourcePath resource path
+     * @param representation representation
+     */
+    @SuppressWarnings("SameParameterValue")
+    public void sendAdminEvent(
+            ScimContext scimContext,
+            OperationType operationType,
+            ResourceType resourceType,
+            String resourcePath,
+            Object representation
+    ) {
+        sendAdminEvent(scimContext, operationType, resourceType, resourcePath, representation, null);
+    }
+
+    /**
+     * Sends an admin event with additional details
+     *
+     * @param scimContext SCIM context
+     * @param operationType operation type
+     * @param resourceType resource type
+     * @param resourcePath resource path
+     * @param representation representation
+     * @param details additional details
+     */
+    public void sendAdminEvent(
+            ScimContext scimContext,
+            OperationType operationType,
+            ResourceType resourceType,
+            String resourcePath,
+            Object representation,
+            Map<String, String> details
+    ) {
+        RealmModel realm = scimContext.getRealm();
+        KeycloakSession session = scimContext.getSession();
+
+        boolean includeRepresentation = realm.isAdminEventsDetailsEnabled();
+
+        AdminEvent event = new AdminEvent();
+        event.setId(UUID.randomUUID().toString());
+        event.setRealmId(realm.getId());
+        event.setRealmName(realm.getName());
+        event.setOperationType(operationType);
+        event.setResourceType(resourceType);
+        event.setResourcePath(resourcePath);
+        event.setTime(System.currentTimeMillis());
+        event.setDetails(details);
+
+        AuthDetails authDetails = new AuthDetails();
+        authDetails.setRealmId(scimContext.getRealm().getId());
+        authDetails.setRealmName(scimContext.getRealm().getName());
+        authDetails.setUserId("SCIM_CLIENT");
+        event.setAuthDetails(authDetails);
+
+        if (representation != null) {
+            try {
+                event.setRepresentation(JsonSerialization.writeValueAsString(representation));
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        List<String> realmListenerIds = realm.getEventsListenersStream().toList();
+
+        if (realm.isAdminEventsEnabled()) {
+            EventStoreProvider store = session.getProvider(EventStoreProvider.class);
+            if (store != null) {
+                store.onEvent(event, includeRepresentation);
+            }
+        }
+
+        session.getKeycloakSessionFactory()
+                .getProviderFactoriesStream(EventListenerProvider.class)
+                .filter(providerFactory -> realmListenerIds.contains(providerFactory.getId()) || ((EventListenerProviderFactory) providerFactory).isGlobal())
+                .map(providerFactory -> providerFactory.create(session))
+                .forEach(provider -> {
+                    if (provider instanceof EventListenerProvider eventListenerProvider) {
+                        eventListenerProvider.onEvent(event, includeRepresentation);
+                    }
+                });
+    }
+}

--- a/src/main/java/fi/metatavu/keycloak/scim/server/groups/GroupsController.java
+++ b/src/main/java/fi/metatavu/keycloak/scim/server/groups/GroupsController.java
@@ -2,6 +2,7 @@ package fi.metatavu.keycloak.scim.server.groups;
 
 import fi.metatavu.keycloak.scim.server.AbstractController;
 import fi.metatavu.keycloak.scim.server.ScimContext;
+import fi.metatavu.keycloak.scim.server.adminEvents.AdminEventController;
 import fi.metatavu.keycloak.scim.server.metadata.GroupAttribute;
 import fi.metatavu.keycloak.scim.server.patch.PatchOperation;
 import fi.metatavu.keycloak.scim.server.consts.Schemas;
@@ -10,10 +11,14 @@ import fi.metatavu.keycloak.scim.server.model.GroupMembersInner;
 import fi.metatavu.keycloak.scim.server.model.GroupsList;
 import fi.metatavu.keycloak.scim.server.patch.UnsupportedPatchOperation;
 import org.jboss.logging.Logger;
+import org.keycloak.events.admin.OperationType;
+import org.keycloak.events.admin.ResourceType;
 import org.keycloak.models.GroupModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
+import org.keycloak.models.utils.ModelToRepresentation;
+import org.keycloak.representations.idm.GroupRepresentation;
 
 import java.util.Collections;
 import java.util.List;
@@ -26,6 +31,7 @@ import java.util.stream.Collectors;
 public class GroupsController extends AbstractController {
 
     private static final Logger logger = Logger.getLogger(GroupsController.class);
+    private final AdminEventController adminEventController = new AdminEventController();
 
     /**
      * Creates a group
@@ -51,6 +57,8 @@ public class GroupsController extends AbstractController {
                 }
             }
         }
+
+        dispatchGroupCreateEvent(scimContext, group);
 
         return translateGroup(scimContext, group);
     }
@@ -187,6 +195,7 @@ public class GroupsController extends AbstractController {
                                 UserModel user = scimContext.getSession().users().getUserById(scimContext.getRealm(), memberId);
                                 if (user != null) {
                                     user.joinGroup(existing);
+                                    dispatchGroupMembershipJoinEvent(scimContext, existing, user);
                                 }
                             }
                         }
@@ -212,6 +221,7 @@ public class GroupsController extends AbstractController {
                                 UserModel user = scimContext.getSession().users().getUserById(scimContext.getRealm(), memberId);
                                 if (user != null) {
                                     user.leaveGroup(existing);
+                                    dispatchGroupMembershipLeaveEvent(scimContext, existing, user);
                                 }
                             }
                         }
@@ -233,6 +243,8 @@ public class GroupsController extends AbstractController {
         KeycloakSession session = scimContext.getSession();
         RealmModel realm = scimContext.getRealm();
         session.groups().removeGroup(realm, group);
+
+        dispatchGroupDeleteEvent(scimContext, group);
     }
 
     /**
@@ -261,5 +273,99 @@ public class GroupsController extends AbstractController {
                 .members(members)
                 .schemas(Collections.singletonList(Schemas.GROUP_SCHEMA))
                 .meta(getMeta(scimContext, "Group", String.format("Groups/%s", group.getId())));
+    }
+
+    /**
+     * Dispatches group create event
+     *
+     * @param scimContext SCIM context
+     * @param group group
+     */
+    protected void dispatchGroupCreateEvent(
+            ScimContext scimContext,
+            GroupModel group
+    ) {
+        GroupRepresentation groupRepresentation = ModelToRepresentation.toRepresentation(group, false);
+
+        adminEventController.sendAdminEvent(
+                scimContext,
+                OperationType.CREATE,
+                ResourceType.GROUP,
+                "groups/" + group.getId(),
+                groupRepresentation
+        );
+    }
+
+    /**
+     * Dispatches group creation event
+     *
+     * @param scimContext SCIM context
+     * @param group group
+     */
+    protected void dispatchGroupDeleteEvent(
+            ScimContext scimContext,
+            GroupModel group
+    ) {
+        adminEventController.sendAdminEvent(
+                scimContext,
+                OperationType.DELETE,
+                ResourceType.GROUP,
+                "groups/" + group.getId(),
+                null
+        );
+    }
+
+    /**
+     * Dispatches group membership join event
+     *
+     * @param scimContext SCIM context
+     * @param group group
+     * @param user user
+     */
+    protected void dispatchGroupMembershipJoinEvent(
+            ScimContext scimContext,
+            GroupModel group,
+            UserModel user
+    ) {
+        GroupRepresentation groupRepresentation = ModelToRepresentation.toRepresentation(group, false);
+
+        adminEventController.sendAdminEvent(
+                scimContext,
+                OperationType.CREATE,
+                ResourceType.GROUP_MEMBERSHIP,
+                "groups/" + group.getId() + "/members/" + user.getId(),
+                groupRepresentation,
+                 Map.of(
+                         UserModel.USERNAME, user.getUsername(),
+                        UserModel.EMAIL, user.getEmail()
+                )
+        );
+    }
+
+    /**
+     * Dispatches group membership leave event
+     *
+     * @param scimContext SCIM context
+     * @param group group
+     * @param user user
+     */
+    protected void dispatchGroupMembershipLeaveEvent(
+            ScimContext scimContext,
+            GroupModel group,
+            UserModel user
+    ) {
+        GroupRepresentation groupRepresentation = ModelToRepresentation.toRepresentation(group, false);
+
+        adminEventController.sendAdminEvent(
+                scimContext,
+                OperationType.DELETE,
+                ResourceType.GROUP_MEMBERSHIP,
+                "groups/" + group.getId() + "/members/" + user.getId(),
+                groupRepresentation,
+                Map.of(
+                        UserModel.USERNAME, user.getUsername(),
+                        UserModel.EMAIL, user.getEmail()
+                )
+        );
     }
 }

--- a/src/main/java/fi/metatavu/keycloak/scim/server/organization/OrganizationUserController.java
+++ b/src/main/java/fi/metatavu/keycloak/scim/server/organization/OrganizationUserController.java
@@ -1,5 +1,6 @@
 package fi.metatavu.keycloak.scim.server.organization;
 
+import fi.metatavu.keycloak.scim.server.adminEvents.AdminEventController;
 import fi.metatavu.keycloak.scim.server.config.ScimConfig;
 import fi.metatavu.keycloak.scim.server.consts.ScimRoles;
 import fi.metatavu.keycloak.scim.server.filter.ScimFilter;
@@ -28,6 +29,8 @@ import java.util.Map;
 public class OrganizationUserController extends UsersController  {
 
     private static final Logger logger = Logger.getLogger(OrganizationUserController.class);
+    private final AdminEventController adminEventController = new AdminEventController();
+
 
     /**
      * Creates a user
@@ -490,7 +493,7 @@ public class OrganizationUserController extends UsersController  {
             eventDetails.put(UserModel.EMAIL, member.getEmail());
         }
 
-        sendAdminEvent(
+        adminEventController.sendAdminEvent(
             scimContext,
             OperationType.CREATE,
             ResourceType.ORGANIZATION_MEMBERSHIP,
@@ -521,7 +524,7 @@ public class OrganizationUserController extends UsersController  {
             eventDetails.put(UserModel.EMAIL, member.getEmail());
         }
 
-        sendAdminEvent(
+        adminEventController.sendAdminEvent(
             scimContext,
             OperationType.DELETE,
             ResourceType.ORGANIZATION_MEMBERSHIP,

--- a/src/main/java/fi/metatavu/keycloak/scim/server/users/UsersController.java
+++ b/src/main/java/fi/metatavu/keycloak/scim/server/users/UsersController.java
@@ -2,6 +2,7 @@ package fi.metatavu.keycloak.scim.server.users;
 
 import fi.metatavu.keycloak.scim.server.AbstractController;
 import fi.metatavu.keycloak.scim.server.ScimContext;
+import fi.metatavu.keycloak.scim.server.adminEvents.AdminEventController;
 import fi.metatavu.keycloak.scim.server.consts.Schemas;
 import fi.metatavu.keycloak.scim.server.consts.ScimRoles;
 import fi.metatavu.keycloak.scim.server.filter.ComparisonFilter;
@@ -19,17 +20,12 @@ import fi.metatavu.keycloak.scim.server.patch.UnsupportedPatchOperation;
 import fi.metatavu.keycloak.scim.server.realm.RealmScimContext;
 import jakarta.ws.rs.NotFoundException;
 import org.jboss.logging.Logger;
-import org.keycloak.events.EventListenerProvider;
-import org.keycloak.events.EventListenerProviderFactory;
-import org.keycloak.events.admin.AdminEvent;
 import org.keycloak.events.admin.OperationType;
 import org.keycloak.events.admin.ResourceType;
 import org.keycloak.models.*;
 import org.keycloak.models.utils.ModelToRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
-import org.keycloak.util.JsonSerialization;
 
-import java.io.IOException;
 import java.util.*;
 
 /**
@@ -38,6 +34,7 @@ import java.util.*;
 public class UsersController extends AbstractController {
 
     private static final Logger logger = Logger.getLogger(UsersController.class);
+    private final AdminEventController adminEventController = new AdminEventController();
 
     /**
      * Creates a user
@@ -326,7 +323,7 @@ public class UsersController extends AbstractController {
         RealmModel realm = scimContext.getRealm();
         UserRepresentation userRepresentation = ModelToRepresentation.toRepresentation(session, realm, user);
 
-        sendAdminEvent(
+        adminEventController.sendAdminEvent(
             scimContext,
             OperationType.CREATE,
             ResourceType.USER,
@@ -336,7 +333,7 @@ public class UsersController extends AbstractController {
     }
 
     /**
-     * Dispatches user creation event
+     * Dispatches user deletion event
      *
      * @param scimContext SCIM context
      * @param user user
@@ -345,7 +342,7 @@ public class UsersController extends AbstractController {
         ScimContext scimContext,
         UserModel user
     ) {
-        sendAdminEvent(
+        adminEventController.sendAdminEvent(
             scimContext,
             OperationType.DELETE,
             ResourceType.USER,
@@ -368,87 +365,13 @@ public class UsersController extends AbstractController {
         RealmModel realm = scimContext.getRealm();
         UserRepresentation userRepresentation = ModelToRepresentation.toRepresentation(session, realm, user);
 
-        sendAdminEvent(
+        adminEventController.sendAdminEvent(
             scimContext,
             OperationType.UPDATE,
             ResourceType.USER,
             "users/" + user.getId(),
             userRepresentation
         );
-    }
-
-    /**
-     * Sends an admin event
-     *
-     * @param scimContext SCIM context
-     * @param operationType operation type
-     * @param resourceType resource type
-     * @param resourcePath resource path
-     * @param representation representation
-     */
-    @SuppressWarnings("SameParameterValue")
-    protected void sendAdminEvent(
-        ScimContext scimContext,
-        OperationType operationType,
-        ResourceType resourceType,
-        String resourcePath,
-        Object representation
-    ) {
-        sendAdminEvent(scimContext, operationType, resourceType, resourcePath, representation, null);
-    }
-
-    /**
-     * Sends an admin event with additional details
-     *
-     * @param scimContext SCIM context
-     * @param operationType operation type
-     * @param resourceType resource type
-     * @param resourcePath resource path
-     * @param representation representation
-     * @param details additional details
-     */
-    protected void sendAdminEvent(
-        ScimContext scimContext,
-        OperationType operationType,
-        ResourceType resourceType,
-        String resourcePath,
-        Object representation,
-        Map<String, String> details
-    ) {
-        RealmModel realm = scimContext.getRealm();
-        KeycloakSession session = scimContext.getSession();
-
-        boolean includeRepresentation = realm.isAdminEventsDetailsEnabled();
-
-        AdminEvent event = new AdminEvent();
-        event.setId(UUID.randomUUID().toString());
-        event.setRealmId(realm.getId());
-        event.setRealmName(realm.getName());
-        event.setOperationType(operationType);
-        event.setResourceType(resourceType);
-        event.setResourcePath(resourcePath);
-        event.setTime(System.currentTimeMillis());
-        event.setDetails(details);
-
-        if (representation != null) {
-            try {
-                event.setRepresentation(JsonSerialization.writeValueAsString(representation));
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
-        }
-
-        List<String> realmListenerIds = realm.getEventsListenersStream().toList();
-
-        session.getKeycloakSessionFactory()
-            .getProviderFactoriesStream(EventListenerProvider.class)
-            .filter(providerFactory -> realmListenerIds.contains(providerFactory.getId()) || ((EventListenerProviderFactory) providerFactory).isGlobal())
-            .map(providerFactory -> providerFactory.create(session))
-            .forEach(provider -> {
-                if (provider instanceof EventListenerProvider eventListenerProvider) {
-                    eventListenerProvider.onEvent(event, includeRepresentation);
-                }
-            });
     }
 
     /**


### PR DESCRIPTION
Hi 

Following my [reported issue](https://github.com/Metatavu/keycloak-scim-server/issues/38), I've dived in the code and did a few improvements:
- added authDetails to the event (was causing issues for me when tracing is enabled)
- added event storage: events are now stored in database
- added group add/delete events 
- added groupmembership add/delete events

Thanks
