### PR TITLE
Throw 400 on group creation when displayName is missing

### DIFF
--- a/src/main/java/fi/metatavu/keycloak/scim/server/realm/RealmScimServer.java
+++ b/src/main/java/fi/metatavu/keycloak/scim/server/realm/RealmScimServer.java
@@ -7,7 +7,6 @@ import fi.metatavu.keycloak.scim.server.groups.UnsupportedGroupPath;
 import fi.metatavu.keycloak.scim.server.metadata.UserAttributes;
 import fi.metatavu.keycloak.scim.server.model.User;
 import fi.metatavu.keycloak.scim.server.patch.UnsupportedPatchOperation;
-import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.InternalServerErrorException;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.core.Response;
@@ -188,7 +187,7 @@ public class RealmScimServer extends AbstractScimServer<RealmScimContext> {
 
         if (isBlank(createRequest.getDisplayName())) {
             logger.warn("Cannot create group: Missing displayName");
-            throw new BadRequestException("Missing displayName");
+            return Response.status(Response.Status.BAD_REQUEST).entity("Missing displayName").build();
         }
 
         fi.metatavu.keycloak.scim.server.model.Group created = groupsController.createGroup(scimContext, createRequest);

--- a/src/test/java/fi/metatavu/keycloak/scim/server/test/ScimClient.java
+++ b/src/test/java/fi/metatavu/keycloak/scim/server/test/ScimClient.java
@@ -2,6 +2,7 @@ package fi.metatavu.keycloak.scim.server.test;
 
 import fi.metatavu.keycloak.scim.server.test.client.ApiClient;
 import fi.metatavu.keycloak.scim.server.test.client.ApiException;
+import fi.metatavu.keycloak.scim.server.test.client.api.GroupsApi;
 import fi.metatavu.keycloak.scim.server.test.client.api.MetadataApi;
 import fi.metatavu.keycloak.scim.server.test.client.api.UsersApi;
 import fi.metatavu.keycloak.scim.server.test.client.model.*;
@@ -144,12 +145,53 @@ public class ScimClient {
     }
 
     /**
+     * Creates a group
+     *
+     * @param group group to create
+     * @return created group
+     * @throws ApiException thrown when API call fails
+     */
+    public Group createGroup(Group group) throws ApiException {
+        return getGroupsApi().createGroup(group);
+    }
+
+    /**
+     * Finds a group
+     *
+     * @param id group ID
+     * @return found group
+     * @throws ApiException thrown when API call fails
+     */
+    public Group findGroup(String id) throws ApiException {
+        return getGroupsApi().getGroup(id);
+    }
+
+    /**
+     * Deletes a group
+     *
+     * @param groupId group ID
+     * @throws ApiException thrown when API call fails
+     */
+    public void deleteGroup(String groupId) throws ApiException {
+        getGroupsApi().deleteGroup(groupId);
+    }
+
+    /**
      * Returns initialized users API
      *
      * @return initialized users API
      */
     private UsersApi getUsersApi() {
         return new UsersApi(getApiClient());
+    }
+
+    /**
+     * Returns initialized groups API
+     *
+     * @return initialized groups API
+     */
+    private GroupsApi getGroupsApi() {
+        return new GroupsApi(getApiClient());
     }
 
     private MetadataApi getMetadataApi() {

--- a/src/test/java/fi/metatavu/keycloak/scim/server/test/tests/AbstractScimTest.java
+++ b/src/test/java/fi/metatavu/keycloak/scim/server/test/tests/AbstractScimTest.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import dasniko.testcontainers.keycloak.KeycloakContainer;
 import fi.metatavu.keycloak.scim.server.test.ScimClient;
 import fi.metatavu.keycloak.scim.server.test.client.ApiException;
+import fi.metatavu.keycloak.scim.server.test.client.model.Group;
 import fi.metatavu.keycloak.scim.server.test.client.model.User;
 import fi.metatavu.keycloak.scim.server.test.client.model.UserEmailsInner;
 import fi.metatavu.keycloak.scim.server.test.client.model.UserName;
@@ -16,6 +17,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.keycloak.events.admin.AdminEvent;
 import org.keycloak.events.admin.OperationType;
 import org.keycloak.events.admin.ResourceType;
+import org.keycloak.representations.idm.GroupRepresentation;
 import org.keycloak.representations.idm.MemberRepresentation;
 import org.keycloak.representations.idm.RoleRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
@@ -227,6 +229,57 @@ public abstract class AbstractScimTest {
         for (User user : users) {
             deleteRealmUser(realm, user.getId());
         }
+    }
+
+    /**
+     * Creates a group with the given parameters
+     *
+     * @param scimClient SCIM client
+     * @param displayName display name
+     * @return created group
+     * @throws ApiException if an error occurs during group creation
+     */
+    protected Group createGroup(
+        ScimClient scimClient,
+        String displayName
+    ) throws ApiException {
+        Group group = new Group();
+        group.setDisplayName(displayName);
+        group.setSchemas(List.of("urn:ietf:params:scim:schemas:core:2.0:Group"));
+        Group created = scimClient.createGroup(group);
+        assertNotNull(created);
+        return created;
+    }
+
+    /**
+     * Finds group from Keycloak
+     *
+     * @param realm realm name
+     * @param groupId group ID
+     * @return group representation
+     */
+    protected GroupRepresentation findRealmGroup(String realm, String groupId) {
+        return getKeycloakContainer().getKeycloakAdminClient()
+            .realms()
+            .realm(realm)
+            .groups()
+            .group(groupId)
+            .toRepresentation();
+    }
+
+    /**
+     * Deletes group from Keycloak
+     *
+     * @param realm realm name
+     * @param groupId group ID
+     */
+    protected void deleteRealmGroup(String realm, String groupId) {
+        getKeycloakContainer().getKeycloakAdminClient()
+            .realms()
+            .realm(realm)
+            .groups()
+            .group(groupId)
+            .remove();
     }
 
     /**

--- a/src/test/java/fi/metatavu/keycloak/scim/server/test/tests/functional/RealmGroupCreateTestsIT.java
+++ b/src/test/java/fi/metatavu/keycloak/scim/server/test/tests/functional/RealmGroupCreateTestsIT.java
@@ -1,0 +1,74 @@
+package fi.metatavu.keycloak.scim.server.test.tests.functional;
+
+import fi.metatavu.keycloak.scim.server.test.tests.AbstractInternalAuthRealmScimTest;
+import fi.metatavu.keycloak.scim.server.test.ScimClient;
+import fi.metatavu.keycloak.scim.server.test.TestConsts;
+import fi.metatavu.keycloak.scim.server.test.client.ApiException;
+import fi.metatavu.keycloak.scim.server.test.client.model.Group;
+import org.junit.jupiter.api.Test;
+import org.keycloak.representations.idm.GroupRepresentation;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for SCIM 2.0 Group create endpoint
+ */
+@Testcontainers
+public class RealmGroupCreateTestsIT extends AbstractInternalAuthRealmScimTest {
+
+    @Test
+    void testCreateGroup() throws ApiException {
+        ScimClient scimClient = getAuthenticatedScimClient();
+
+        Group group = new Group();
+        group.setDisplayName("test-group");
+        group.setSchemas(List.of("urn:ietf:params:scim:schemas:core:2.0:Group"));
+
+        Group created = scimClient.createGroup(group);
+
+        assertNotNull(created);
+        assertNotNull(created.getId());
+        assertEquals("test-group", created.getDisplayName());
+        assertEquals(List.of("urn:ietf:params:scim:schemas:core:2.0:Group"), created.getSchemas());
+
+        // Assert that the group was created in Keycloak
+        GroupRepresentation realmGroup = findRealmGroup(TestConsts.TEST_REALM, created.getId());
+        assertNotNull(realmGroup);
+        assertEquals("test-group", realmGroup.getName());
+
+        // Clean up
+        deleteRealmGroup(TestConsts.TEST_REALM, realmGroup.getId());
+    }
+
+    @Test
+    void testCreateGroupWithoutDisplayNameReturnsBadRequest() {
+        ScimClient scimClient = getAuthenticatedScimClient();
+
+        Group group = new Group();
+        group.setSchemas(List.of("urn:ietf:params:scim:schemas:core:2.0:Group"));
+
+        ApiException exception = assertThrows(ApiException.class, () ->
+            scimClient.createGroup(group)
+        );
+
+        assertEquals(400, exception.getCode());
+    }
+
+    @Test
+    void testCreateGroupWithBlankDisplayNameReturnsBadRequest() {
+        ScimClient scimClient = getAuthenticatedScimClient();
+
+        Group group = new Group();
+        group.setDisplayName("   ");
+        group.setSchemas(List.of("urn:ietf:params:scim:schemas:core:2.0:Group"));
+
+        ApiException exception = assertThrows(ApiException.class, () ->
+            scimClient.createGroup(group)
+        );
+
+        assertEquals(400, exception.getCode());
+    }
+}


### PR DESCRIPTION
On SCIM API, when creating a group, if you omit displayName while it's required by the rfc-7643, it creates a group with displayName=null.

Then Keycloak admin console bugs on groups and user groups.