### PR TITLE
Use Keycloak's HttpClientProvider to jwks download

### DIFF
--- a/src/main/java/fi/metatavu/keycloak/scim/server/AbstractScimServer.java
+++ b/src/main/java/fi/metatavu/keycloak/scim/server/AbstractScimServer.java
@@ -143,7 +143,7 @@ public abstract class AbstractScimServer <T extends ScimContext> implements Scim
             );
 
             try {
-                if (!verifier.verify(tokenString)) {
+                if (!verifier.verify(tokenString, scimContext)) {
                     logger.warn("External token verification failed");
                     throw new NotAuthorizedException("External token verification failed");
                 }

--- a/src/main/java/fi/metatavu/keycloak/scim/server/authentication/ExternalTokenVerifier.java
+++ b/src/main/java/fi/metatavu/keycloak/scim/server/authentication/ExternalTokenVerifier.java
@@ -1,5 +1,6 @@
 package fi.metatavu.keycloak.scim.server.authentication;
 
+import fi.metatavu.keycloak.scim.server.ScimContext;
 import org.jboss.logging.Logger;
 import org.keycloak.jose.jws.JWSInput;
 
@@ -40,10 +41,11 @@ public class ExternalTokenVerifier {
      * Verifies the given token.
      *
      * @param tokenString JWT token string
+     * @param scimContext the context, used to retrieve a Keycloak HTTP client
      * @return true if the token is valid, false otherwise
      */
-    public boolean verify(String tokenString) throws URISyntaxException, IOException, InterruptedException, JWSInputException {
-        for (JwkKey jwkKey : JwksUtils.getPublicKeysFromJwks(jwksUrl)) {
+    public boolean verify(String tokenString, ScimContext scimContext) throws URISyntaxException, IOException, InterruptedException, JWSInputException {
+        for (JwkKey jwkKey : JwksUtils.getPublicKeysFromJwks(jwksUrl, scimContext)) {
             if (verify(tokenString, jwkKey.getPublicKey())) {
                 logger.info("Token verification succeeded with key: " + jwkKey.getKid());
                 return true;

--- a/src/main/java/fi/metatavu/keycloak/scim/server/authentication/JwksUtils.java
+++ b/src/main/java/fi/metatavu/keycloak/scim/server/authentication/JwksUtils.java
@@ -2,14 +2,16 @@ package fi.metatavu.keycloak.scim.server.authentication;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import fi.metatavu.keycloak.scim.server.ScimContext;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.keycloak.connections.httpclient.HttpClientProvider;
 import org.keycloak.jose.jwk.JWKParser;
 
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
 import java.security.PublicKey;
 import java.util.ArrayList;
 import java.util.List;
@@ -23,27 +25,28 @@ public class JwksUtils {
     /**
      * Loads all public keys from JWKS URL
      *
-     * @param jwksUrl JWKS endpoint URL
+     * @param jwksUrl     JWKS endpoint URL
+     * @param scimContext the context, used to retrieve a Keycloak HTTP client
      * @return list of public keys
      */
-    public static List<JwkKey> getPublicKeysFromJwks(String jwksUrl) throws URISyntaxException, IOException, InterruptedException {
+    public static List<JwkKey> getPublicKeysFromJwks(String jwksUrl, ScimContext scimContext) throws URISyntaxException, IOException, InterruptedException {
         List<JwkKey> result = new ArrayList<>();
 
-        try (HttpClient httpClient = HttpClient.newHttpClient()) {
-            HttpRequest request = HttpRequest.newBuilder()
-                .uri(new URI(jwksUrl))
-                .GET()
-                .build();
+        HttpClientProvider clientProvider = scimContext.getSession().getProvider(HttpClientProvider.class);
+        // never close an HttpClient from the Keycloak pool
+        CloseableHttpClient httpClient = clientProvider.getHttpClient();
 
-            HttpResponse<byte[]> response = httpClient.send(request, HttpResponse.BodyHandlers.ofByteArray());
+        HttpGet request = new HttpGet(new URI(jwksUrl));
+        try (CloseableHttpResponse response = httpClient.execute(request)) {
 
-            if (response.statusCode() != 200) {
-                throw new RuntimeException("Failed to fetch JWKS: HTTP " + response.statusCode());
+            int statusCode = response.getStatusLine().getStatusCode();
+            if (statusCode != 200) {
+                throw new RuntimeException("Failed to fetch JWKS: HTTP " + statusCode);
             }
 
             ObjectMapper objectMapper = new ObjectMapper();
 
-            Map<String, Object> jwks = objectMapper.readValue(response.body(), new TypeReference<>() { });
+            Map<String, Object> jwks = objectMapper.readValue(response.getEntity().getContent(), new TypeReference<>() { });
             @SuppressWarnings("unchecked")
             List<Map<String, Object>> keys = (List<Map<String, Object>>) jwks.get("keys");
 
@@ -63,14 +66,12 @@ public class JwksUtils {
 
                 String jwkJson = objectMapper.writeValueAsString(jwk);
                 PublicKey publicKey = JWKParser.create()
-                    .parse(jwkJson)
-                    .toPublicKey();
+                        .parse(jwkJson)
+                        .toPublicKey();
 
                 result.add(new JwkKey(publicKey, kid, use));
             }
-
-            return result;
         }
+        return result;
     }
-
 }


### PR DESCRIPTION
Use HttpClientProvider to get an HttpClient instead of creating a default one. These are taken from Keycloak's internal connection pool and natively support a proxy.