### PR TITLE
fix: email PATCH path for Entra ID compatibility

### DIFF
--- a/src/main/java/fi/metatavu/keycloak/scim/server/metadata/UserAttributes.java
+++ b/src/main/java/fi/metatavu/keycloak/scim/server/metadata/UserAttributes.java
@@ -22,15 +22,27 @@ public class UserAttributes {
             .collect(Collectors.toMap(UserAttribute::getScimPath, Function.identity()));
     }
 
-    /**
+    /**                                                                                                                                                                                     
      * Finds user attribute by SCIM path
-     *
+     *                                                                                                                                                                                      
      * @param scimPath SCIM path
      * @return user attribute or null if not found
      */
     public UserAttribute<?> findByScimPath(String scimPath) {
-        return attributeMap.get(scimPath);
+        UserAttribute<?> result = attributeMap.get(scimPath);
+        if (result != null) {
+            return result;
+        }
+
+        // Fix: Entra ID sends emails[type eq "work"].value as SCIM path on PATCH
+        // but the plugin registers this attribute as "email"
+        if (scimPath != null && scimPath.startsWith("emails")) {
+            return attributeMap.get("email");
+        }
+
+        return null;
     }
+
 
     /**
      * Lists user attributes by source


### PR DESCRIPTION
# Problem

Microsoft Entra ID sends `emails[type eq "work"].value` as the SCIM path in PATCH requests when updating a user's email. The plugin registers the email attribute under the key `"email"`, so `findByScimPath()` returns `null` → throws `UnsupportedUserPath` → 500 Internal Server Error.

This only affects PATCH (email update on existing user). POST (user creation) works fine because it parses the `emails` JSON array directly.

## SCIM request from Entra ID that fails

  ```json
  {
    "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
    "Operations": [
      {
        "op": "Replace",
        "path": "emails[type eq \"work\"].value",
        "value": "newemail@example.com"
      }
    ]
  }
 ```
## Fix

  In UserAttributes.findByScimPath(): if the exact lookup fails and the path starts with "emails", fall back to the "email" attribute.

Fixes #35