### PR TITLE
Added basic auth for okta compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,34 @@
 
 This project provides a **SCIM 2.0-compliant extension** for [Keycloak](https://www.keycloak.org/), enabling SCIM-based user and group provisioning. It supports:
 
-- **Realm-level SCIM APIs**:  
+- **Realm-level SCIM APIs**:
   `/realms/{realm}/scim/v2`
-- **Organization-level SCIM APIs** (Keycloak 26+ with Organizations):  
+- **Organization-level SCIM APIs** (Keycloak 26+ with Organizations):
   `/realms/{realm}/scim/v2/organizations/{organizationId}`
+
+## Table of Contents
+
+- [Prerequisites](#prerequisites)
+- [Installation](#installation)
+  - [Option 1: Include from GitHub Release](#option-1-include-it-directly-from-github-release)
+  - [Option 2: Install from GitHub Packages](#option-2-install-from-github-packages-recommended)
+  - [Option 3: Build from Source](#option-3-build-from-source)
+- [Configuration](#configuration)
+  - [Instance-Level Configuration](#instance-level-configuration)
+  - [Realm-Level Configuration](#realm-level-configuration)
+  - [Organization-Level Configuration](#organization-level-configuration)
+- [Authentication](#authentication)
+  - [Keycloak Authentication](#keycloak-authentication)
+  - [External JWT (JWKS) Authentication](#external-jwt-jwks-authentication)
+  - [External Shared Secret (Bearer Token) Authentication](#external-shared-secret-bearer-token-authentication)
+  - [External Basic Auth Authentication](#external-basic-auth-authentication)
+- [Vendor Configuration Guides](#vendor-configuration-guides)
+  - [Microsoft Entra ID](#microsoft-entra-id)
+  - [Okta](#okta)
+- [Identity Provider Linking](#identity-provider-linking)
+  - [Identity Provider Linking with Azure Entra ID](#identity-provider-linking-with-azure-entra-id)
+- [SCIM-Managed Users](#scim-managed-users)
+- [License](#license)
 
 ## Prerequisites
 
@@ -15,6 +39,7 @@ This project provides a **SCIM 2.0-compliant extension** for [Keycloak](https://
 ## Installation
 
 ### Option 1: Include it directly from GitHub Release
+
 You can reference the JAR file from a GitHub Release directly in your init container or Dockerfile.
 
 For example, using a Helm `values.yaml`:
@@ -43,15 +68,14 @@ extraVolumes: |
 
 ### Option 2: Install from GitHub Packages (recommended)
 
-Download the JAR file from GitHub packages. 
+Download the JAR file from GitHub packages.
 
 1. Download the latest JAR from: [GitHub Packages](https://github.com/Metatavu/keycloak-scim-server/packages/2454996)
 2. Copy it to your Keycloak instance:
 ```bash
-   cp keycloak-scim-server-*.jar $KEYCLOAK_HOME/providers/
+cp keycloak-scim-server-*.jar $KEYCLOAK_HOME/providers/
 ```
 3. Restart Keycloak.
-
 
 ### Option 3: Build from Source
 
@@ -66,29 +90,30 @@ cp build/libs/keycloak-scim-server-*.jar $KEYCLOAK_HOME/providers/
 
 ## Configuration
 
-### Configuration on Instance level
+All settings can be applied at three levels. Settings at a more specific level override broader ones (organization > realm > instance).
 
-Configuration on instance level is done by defining environment variables in the Keycloak server. 
+### Instance-Level Configuration
 
-The following environment variables are available:
+Configuration on instance level is done by defining environment variables on the Keycloak server.
 
-| Setting                                    | Value                                                                                                                                                                                                                      |
-|--------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| SCIM_AUTHENTICATION_MODE                   | Authentication mode for SCIM API. Possible values are KEYCLOAK and EXTERNAL. If the value is not set the server will respond unauthorzed for all requests.                                                                 |
-| SCIM_EXTERNAL_ISSUER                       | Issuer for the external authentication. This is used to validate the JWT token.                                                                                                                                            |
-| SCIM_EXTERNAL_AUDIENCE                     | JWKS URI for the external authentication. This is used to validate the JWT token.                                                                                                                                          |
-| SCIM_EXTERNAL_JWKS_URI                     | Audience for the external authentication. This is used to validate the JWT token.                                                                                                                                          |
-| SCIM_EXTERNAL_SHARED_SECRET                | Shared secret value used for request authentication/validation.                                                                                                                                                            |
-| SCIM_EXTERNAL_SHARED_SECRET_HASH_ALGORITHM | PHC String Format representing hash algorithms and its parameters, used for request authentication/validation ([must be on of the following](https://www.keycloak.org/docs/26.1.5/server_admin/index.html#hashalgorithm)). |
-| SCIM_LINK_IDP                              | Enables support for linking realm identity provider with user.                                                                                                                                                             |
-| SCIM_IDENTITY_PROVIDER_ALIAS               | Alias of Identity Provider to be linked to the user.                                                                                                                                                                       |
+| Setting                      | Description                                                                                                                                                                                                                |
+|------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `SCIM_AUTHENTICATION_MODE`   | Authentication mode for SCIM API. Possible values are `KEYCLOAK` and `EXTERNAL`. If not set the server will respond unauthorized for all requests.                                                                         |
+| `SCIM_EXTERNAL_ISSUER`       | Issuer for external JWT authentication. Used to validate the JWT token issuer claim.                                                                                                                                       |
+| `SCIM_EXTERNAL_AUDIENCE`     | Audience for external JWT authentication. Used to validate the JWT token audience claim.                                                                                                                                   |
+| `SCIM_EXTERNAL_JWKS_URI`     | JWKS URI for external JWT authentication. Used to fetch public keys for JWT token signature validation.                                                                                                                    |
+| `SCIM_EXTERNAL_SHARED_SECRET`| Shared secret in [PHC String Format](https://github.com/P-H-C/phc-string-format/blob/master/phc-sf-spec.md) used for bearer token authentication/validation.                                                              |
+| `SCIM_BASIC_AUTH_USERNAME`   | Username for HTTP Basic authentication.                                                                                                                                                                                    |
+| `SCIM_BASIC_AUTH_PASSWORD`   | Password hash in [PHC String Format](https://github.com/P-H-C/phc-string-format/blob/master/phc-sf-spec.md) for HTTP Basic authentication.                                                                                |
+| `SCIM_LINK_IDP`              | Enables support for linking realm identity provider with user.                                                                                                                                                             |
+| `SCIM_IDENTITY_PROVIDER_ALIAS`| Alias of Identity Provider to be linked to the user.                                                                                                                                                                      |
 
-### Configuration on Realm level
+### Realm-Level Configuration
 
-The following REST call can be called through the Keycloak Admin API to store the settings under realm attributes. 
+The following REST call can be made through the Keycloak Admin API to store settings as realm attributes. Realm-level settings override instance-level settings.
 
 PUT `/admin/realms/{realm}`
-```
+```json
 {
   "attributes": {
     "scim.authentication.mode": "EXTERNAL|KEYCLOAK",
@@ -96,203 +121,364 @@ PUT `/admin/realms/{realm}`
     "scim.external.jwks.uri": "string",
     "scim.external.audience": "string",
     "scim.external.shared.secret": "string",
-    "scim.external.shared.secret.hash.algorithm": "string"
+    "scim.basic.auth.username": "string",
+    "scim.basic.auth.password": "string",
     "scim.link.idp": "true|false",
     "scim.identity.provider.alias": "string"
   }
 }
 ```
 
-### Configuration on Organization level
+### Organization-Level Configuration
 
-Configuration on organization level is done by defining organization attributes in the Keycloak server.
-The following organization attributes are available:
+Configuration on organization level is done by defining organization attributes in the Keycloak server. Only `EXTERNAL` authentication mode is supported at the organization level.
 
-| Setting                                    | Value                                                                                                                                                                                                                               |
-|--------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| SCIM_AUTHENTICATION_MODE                   | Authentication mode for SCIM API. Possible values are KEYCLOAK and EXTERNAL. If the value is not set the server will respond unauthorzed for all requests. Currently on organization level only EXTERNAL is supported.              |
-| SCIM_EXTERNAL_ISSUER                       | Issuer for the external authentication. This is used to validate the JWT token.                                                                                                                                                     |
-| SCIM_EXTERNAL_AUDIENCE                     | Audience for the external authentication. This is used to validate the JWT token.                                                                                                                                                   |
-| SCIM_EXTERNAL_JWKS_URI                     | JWKS URI for the external authentication. This is used to validate the JWT token.                                                                                                                                                   |
-| SCIM_LINK_IDP                              | Enables support for linking organization identity provider with user.                                                                                                                                                               |
-| SCIM_EMAIL_AS_USERNAME                     | Forces server to user email as username instead of actual username. When this setting is enabled username will be unaffected by any update operations. This setting is currently supported only in organization level configuration |
-| SCIM_EXTERNAL_SHARED_SECRET                | Shared secret value used for request authentication/validation.                                                                                                                                                                     |
-| SCIM_EXTERNAL_SHARED_SECRET_HASH_ALGORITHM | PHC String Format representing hash algorithms and its parameters, used for request authentication/validation ([must be on of the following](https://www.keycloak.org/docs/26.1.5/server_admin/index.html#hashalgorithm)). |
+| Setting                      | Description                                                                                                                                         |
+|------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| `SCIM_AUTHENTICATION_MODE`   | Must be `EXTERNAL`. Only external authentication is supported at the organization level.                                                            |
+| `SCIM_EXTERNAL_ISSUER`       | Issuer for external JWT authentication.                                                                                                             |
+| `SCIM_EXTERNAL_AUDIENCE`     | Audience for external JWT authentication.                                                                                                           |
+| `SCIM_EXTERNAL_JWKS_URI`     | JWKS URI for external JWT authentication.                                                                                                           |
+| `SCIM_EXTERNAL_SHARED_SECRET`| Shared secret in PHC String Format for bearer token authentication.                                                                                 |
+| `SCIM_BASIC_AUTH_USERNAME`   | Username for HTTP Basic authentication.                                                                                                             |
+| `SCIM_BASIC_AUTH_PASSWORD`   | Password hash in PHC String Format for HTTP Basic authentication.                                                                                   |
+| `SCIM_LINK_IDP`              | Enables support for linking organization identity provider with user.                                                                               |
+| `SCIM_EMAIL_AS_USERNAME`     | Forces server to use email as username instead of actual username. When enabled, username will be unaffected by update operations. Organization-level only. |
 
-### Azure Entra ID SCIM Configuration
+## Authentication
 
-This extension is compatible with **Microsoft Entra ID** SCIM provisioning.
+The SCIM server supports four authentication methods. For `EXTERNAL` mode, the method is determined automatically based on the authorization header and configuration.
 
-#### Keycloak Configuration
+### Keycloak Authentication
 
-Before Entra ID can provision users and groups to Keycloak via SCIM, you need to configure SCIM authentication settings.
+Uses Keycloak's built-in service account authentication. The SCIM client authenticates using an OAuth2 client credentials flow against Keycloak itself, and the resulting access token is validated natively.
 
-These settings can be applied either:
+**Required settings:**
 
-* At the realm level (for /realms/{realm}/scim/v2)
-* Or at the organization level (for /realms/organizations/scim/v2/organizations/{organizationId})
+| Setting                    | Value       |
+|----------------------------|-------------|
+| `SCIM_AUTHENTICATION_MODE` | `KEYCLOAK`  |
 
-For more details, refer to the sections [Configuration on Realm Level] and [Configuration on Organization Level in this document].
+**Requirements:**
+- A Keycloak client with **Service Accounts Enabled**
+- The client's service account must have the `scim-access` realm role
 
-SCIM Settings for Entra ID
+**Example:** The SCIM client obtains a token via the Keycloak token endpoint and sends it as a bearer token:
+```
+Authorization: Bearer <keycloak-access-token>
+```
 
-When using Entra ID settings will be following:
+### External JWT (JWKS) Authentication
 
-| Setting                  | Value                                                                        |
-|--------------------------|------------------------------------------------------------------------------|
-| SCIM_AUTHENTICATION_MODE | ```EXTERNAL```                                                               |
-| SCIM_EXTERNAL_ISSUER     | ```https://sts.windows.net/<your-tenant-id>/```                              |
-| SCIM_EXTERNAL_AUDIENCE   | ```8adf8e6e-67b2-4cf2-a259-e3dc5476c621```                                   |
-| SCIM_EXTERNAL_JWKS_URI   | ```https://login.microsoftonline.com/<your-tenant-id>/discovery/v2.0/keys``` |
+Validates a JWT bearer token issued by an external identity provider. The token signature is verified against public keys fetched from the configured JWKS endpoint, and the issuer and audience claims are validated.
 
-Replace <your-tenant-id> with your actual Azure tenant ID.
+**Required settings:**
 
-* SCIM_AUTHENTICATION_MODE enables external authentication support for the SCIM server. In this case the external authentication source will be the Azure Entra ID.
-* SCIM_EXTERNAL_ISSUER ensures the JWT token was issued by your tenant.
-* SCIM_EXTERNAL_AUDIENCE must be exactly 8adf8e6e-67b2-4cf2-a259-e3dc5476c621 — this is the default audience used by Entra ID for non-gallery applications.
-* SCIM_EXTERNAL_JWKS_URI allows Keycloak to fetch public keys for token validation.
+| Setting                    | Value                                      |
+|----------------------------|--------------------------------------------|
+| `SCIM_AUTHENTICATION_MODE` | `EXTERNAL`                                 |
+| `SCIM_EXTERNAL_ISSUER`     | Expected `iss` claim (e.g., `https://sts.windows.net/<tenant-id>/`) |
+| `SCIM_EXTERNAL_AUDIENCE`   | Expected `aud` claim                       |
+| `SCIM_EXTERNAL_JWKS_URI`   | URL to the JWKS endpoint for public keys   |
 
-OR
+**Example request:**
+```
+Authorization: Bearer <jwt-token>
+```
 
-| Setting                     | Value                      |
-|-----------------------------|----------------------------|
-| SCIM_AUTHENTICATION_MODE    | ```EXTERNAL```             |
-| SCIM_EXTERNAL_SHARED_SECRET | ```<token_hashed_value>``` |
+### External Shared Secret (Bearer Token) Authentication
 
-Replace <token_hashed_value> with your hashed token value (using SHA-512 Hex).
+Validates a static bearer token against a pre-configured hash. The client sends the raw secret as a bearer token, and the server verifies it against the stored hash using Keycloak's password hashing infrastructure.
 
-#### Azure Configuration
+**Required settings:**
 
-Step-by-step guide on the Azure:
+| Setting                      | Value                                                |
+|------------------------------|------------------------------------------------------|
+| `SCIM_AUTHENTICATION_MODE`   | `EXTERNAL`                                           |
+| `SCIM_EXTERNAL_SHARED_SECRET`| Hashed token in PHC String Format (e.g., Argon2id)   |
 
-1. Sign in to the [Azure portal](https://portal.azure.com)
-2. Go to **Identity → Applications → Enterprise applications**
-3. Click **+ New application → + Create your own application**
-4. Enter a name for your application (e.g., My Keycloak SCIM).
-5. Choose **Integrate any other application you don't find in the gallery.**
-6. Click **Create** to create the application. The application will open automatically in its management screen.
+The hash must be in [PHC String Format](https://github.com/P-H-C/phc-string-format/blob/master/phc-sf-spec.md) using a [Keycloak-supported hash algorithm](https://www.keycloak.org/docs/26.1.5/server_admin/index.html#hashalgorithm) (e.g., `argon2id`, `pbkdf2-sha512`).
+
+**Example:** If the shared secret is `my-secret-token`, hash it using Argon2id and configure the resulting PHC string:
+```
+SCIM_EXTERNAL_SHARED_SECRET=$argon2id$v=19$m=16,t=2,p=1$<salt>$<hash>
+```
+
+The client then sends the raw secret:
+```
+Authorization: Bearer my-secret-token
+```
+
+### External Basic Auth Authentication
+
+Validates credentials sent via HTTP Basic Authentication. The client sends a Base64-encoded `username:password` pair, and the server verifies the username against the configured value and the password against a stored hash.
+
+**Required settings:**
+
+| Setting                    | Value                                                |
+|----------------------------|------------------------------------------------------|
+| `SCIM_AUTHENTICATION_MODE` | `EXTERNAL`                                           |
+| `SCIM_BASIC_AUTH_USERNAME`  | Expected username                                    |
+| `SCIM_BASIC_AUTH_PASSWORD`  | Password hash in PHC String Format (e.g., Argon2id)  |
+
+The password hash must be in [PHC String Format](https://github.com/P-H-C/phc-string-format/blob/master/phc-sf-spec.md) using a [Keycloak-supported hash algorithm](https://www.keycloak.org/docs/26.1.5/server_admin/index.html#hashalgorithm).
+
+**Example:** If the username is `scim-admin` and password is `my-password`, hash the password using Argon2id and configure:
+```
+SCIM_BASIC_AUTH_USERNAME=scim-admin
+SCIM_BASIC_AUTH_PASSWORD=$argon2id$v=19$m=16,t=2,p=1$<salt>$<hash>
+```
+
+The client then sends:
+```
+Authorization: Basic <base64("scim-admin:my-password")>
+```
+
+## Vendor Configuration Guides
+
+### Microsoft Entra ID
+
+Entra ID supports two authentication options when provisioning to this SCIM server:
+
+#### Option A: JWT Authentication (recommended)
+
+Entra ID sends a bearer token signed by Microsoft's identity platform. The SCIM server validates it using Microsoft's JWKS endpoint.
+
+**Keycloak settings:**
+
+| Setting                    | Value                                                                |
+|----------------------------|----------------------------------------------------------------------|
+| `SCIM_AUTHENTICATION_MODE` | `EXTERNAL`                                                           |
+| `SCIM_EXTERNAL_ISSUER`     | `https://sts.windows.net/<your-tenant-id>/`                          |
+| `SCIM_EXTERNAL_AUDIENCE`   | `8adf8e6e-67b2-4cf2-a259-e3dc5476c621`                               |
+| `SCIM_EXTERNAL_JWKS_URI`   | `https://login.microsoftonline.com/<your-tenant-id>/discovery/v2.0/keys` |
+
+Replace `<your-tenant-id>` with your Azure tenant ID. The audience `8adf8e6e-67b2-4cf2-a259-e3dc5476c621` is the default used by Entra ID for non-gallery applications.
+
+#### Option B: Shared Secret Authentication
+
+Entra ID sends a static bearer token that you generate and configure on both sides.
+
+**Keycloak settings:**
+
+| Setting                      | Value                      |
+|------------------------------|----------------------------|
+| `SCIM_AUTHENTICATION_MODE`   | `EXTERNAL`                 |
+| `SCIM_EXTERNAL_SHARED_SECRET`| `<token_hashed_value>`     |
+
+Replace `<token_hashed_value>` with the PHC String Format hash of your token.
+
+#### Azure Portal Setup
+
+1. Sign in to the [Azure portal](https://portal.azure.com).
+2. Go to **Identity > Applications > Enterprise applications**.
+3. Click **+ New application > + Create your own application**.
+4. Enter a name for your application (e.g., "My Keycloak SCIM").
+5. Choose **Integrate any other application you don't find in the gallery**.
+6. Click **Create**.
 7. In the application's left-hand menu, select **Provisioning**.
 8. Click **+ New configuration**.
 9. Fill in the following:
- - Tenant URL (realm): https://mykeycloak.example.com/realms/my-realm/scim/v2 or 
- - Tenant URL (organization): https://mykeycloak.example.com/realms/my-realm/scim/v2/organizations/{organizationId} 
- - Secret Token: Leave this field empty (the application will use the Entra ID bearer token) OR enter the shared secret value (not hashed).
+   - **Tenant URL** (realm): `https://mykeycloak.example.com/realms/my-realm/scim/v2`
+   - **Tenant URL** (organization): `https://mykeycloak.example.com/realms/my-realm/scim/v2/organizations/{organizationId}`
+   - **Secret Token**: Leave empty for JWT authentication (Option A), or enter the raw shared secret (Option B).
 10. Click **Test Connection** to verify the SCIM endpoint.
 11. Click **Create**.
 12. Navigate to **Attribute Mapping (Preview)**.
 13. Open **Provision Microsoft Entra ID Groups**.
 14. Set **Enabled** to **No**.
 15. Click **Save**.
-16. Go back → **open Provision Microsoft Entra ID Users**.
-17. Open Provision Microsoft Entra ID Users.
-18. Define mappings, following are required for Keycloak extension:
-- userName
-- active
-- emails[type eq "work"].value
-- name.givenName
-- name.familyName
-19. Click Save.
-20. Go back to Provisioning.
-21. Set Provisioning Status to On.
-22. Click Save.
-23. Reload the page to ensure the configuration was saved.
-24. Navigate to **Manage > Users and groups > + Add user/group**.
-25.  Select the user you want to provision and click Assign.
-26. Navigate to **Provision on demand**.
-27. Find the user you just assigned.
-28. Click on the user and select **Provision**.
-29. Verify that the provisioning completes successfully.
+16. Go back and open **Provision Microsoft Entra ID Users**.
+17. Define mappings. The following are required:
+    - `userName`
+    - `active`
+    - `emails[type eq "work"].value`
+    - `name.givenName`
+    - `name.familyName`
+18. Click **Save**.
+19. Go back to **Provisioning**.
+20. Set **Provisioning Status** to **On**.
+21. Click **Save**.
+22. Reload the page to ensure the configuration was saved.
+23. Navigate to **Manage > Users and groups > + Add user/group**.
+24. Select the user you want to provision and click **Assign**.
+25. Navigate to **Provision on demand**.
+26. Find the user you just assigned.
+27. Click on the user and select **Provision**.
+28. Verify that the provisioning completes successfully.
 
-For more information, refer to the following documents: 
+For more information, refer to the [Microsoft Entra ID SCIM provisioning documentation](https://learn.microsoft.com/en-us/entra/identity/saas-apps/tutorial-list).
 
-https://learn.microsoft.com/en-us/entra/identity/saas-apps/tutorial-list
+### Okta
 
-#### Identity Provider Linking with Azure Entra ID
+Okta supports three authentication methods when provisioning to a SCIM server. All three are supported by this extension.
+
+For general Okta SCIM setup, refer to the [Okta SCIM provisioning documentation](https://help.okta.com/en-us/content/topics/apps/apps_app_integration_wizard_scim.htm).
+
+#### Option A: HTTP Header (Bearer Token)
+
+Okta sends a static bearer token in the `Authorization` header. This uses the shared secret authentication method.
+
+**Keycloak settings:**
+
+| Setting                      | Value                                    |
+|------------------------------|------------------------------------------|
+| `SCIM_AUTHENTICATION_MODE`   | `EXTERNAL`                               |
+| `SCIM_EXTERNAL_SHARED_SECRET`| PHC String Format hash of your API token |
+
+**Okta setup:**
+1. In the Okta Admin Console, go to **Applications > Applications**.
+2. Select your SCIM application.
+3. Go to the **Provisioning** tab and click **Configure API Integration**.
+4. Select **HTTP Header** as the authentication mode.
+5. In the **Authorization** field, paste the raw API token (the unhashed value).
+6. Set the **SCIM connector base URL** to: `https://mykeycloak.example.com/realms/my-realm/scim/v2`
+7. Click **Test API Credentials** to verify.
+8. Click **Save**.
+
+#### Option B: Basic Auth
+
+Okta sends credentials via HTTP Basic Authentication (Base64-encoded `username:password`).
+
+**Keycloak settings:**
+
+| Setting                    | Value                                          |
+|----------------------------|-------------------------------------------------|
+| `SCIM_AUTHENTICATION_MODE` | `EXTERNAL`                                      |
+| `SCIM_BASIC_AUTH_USERNAME`  | The username you want Okta to authenticate with |
+| `SCIM_BASIC_AUTH_PASSWORD`  | PHC String Format hash of the password           |
+
+**Okta setup:**
+1. In the Okta Admin Console, go to **Applications > Applications**.
+2. Select your SCIM application.
+3. Go to the **Provisioning** tab and click **Configure API Integration**.
+4. Select **Basic Auth** as the authentication mode.
+5. Enter the **Username** and **Password** (the raw, unhashed values).
+6. Set the **SCIM connector base URL** to: `https://mykeycloak.example.com/realms/my-realm/scim/v2`
+7. Click **Test API Credentials** to verify.
+8. Click **Save**.
+
+#### Option C: OAuth2
+
+Okta obtains an access token from an OAuth2 token endpoint, then sends it as a bearer token. Since Keycloak is itself an OAuth2 provider, you can point Okta at Keycloak's token endpoint. The resulting JWT is then validated by the SCIM server using the JWKS authentication method.
+
+**Keycloak prerequisites:**
+1. Create a Keycloak client with **Client Authentication** enabled (confidential client).
+2. Enable **Service Accounts Enabled** on the client.
+3. Note the client ID and client secret.
+
+**Keycloak settings:**
+
+| Setting                    | Value                                                                              |
+|----------------------------|------------------------------------------------------------------------------------|
+| `SCIM_AUTHENTICATION_MODE` | `EXTERNAL`                                                                         |
+| `SCIM_EXTERNAL_ISSUER`     | `https://mykeycloak.example.com/realms/my-realm`                                   |
+| `SCIM_EXTERNAL_AUDIENCE`   | The client ID of the Keycloak client, or `account`                                 |
+| `SCIM_EXTERNAL_JWKS_URI`   | `https://mykeycloak.example.com/realms/my-realm/protocol/openid-connect/certs`     |
+
+**Okta setup:**
+1. In the Okta Admin Console, go to **Applications > Applications**.
+2. Select your SCIM application.
+3. Go to the **Provisioning** tab and click **Configure API Integration**.
+4. Select **OAuth2** as the authentication mode.
+5. Configure the following:
+   - **Access Token Endpoint**: `https://mykeycloak.example.com/realms/my-realm/protocol/openid-connect/token`
+   - **Client ID**: The Keycloak client ID
+   - **Client Secret**: The Keycloak client secret
+6. Set the **SCIM connector base URL** to: `https://mykeycloak.example.com/realms/my-realm/scim/v2`
+7. Click **Test API Credentials** to verify.
+8. Click **Save**.
+
+## Identity Provider Linking
+
+### Identity Provider Linking with Azure Entra ID
 
 Identity Provider linking with Entra ID requires a few additional configuration steps on both the Entra and Keycloak sides.
 
 **Step 1: Add externalId**
 
-In the Keycloak admin console, ensure that you have externalId attribute defined in your Realm Settings > User Profile. This attribute is used to store user's external id in the Keycloak side and without it the Identity Provider linking will fail. 
+In the Keycloak admin console, ensure that you have an `externalId` attribute defined in your **Realm Settings > User Profile**. This attribute is used to store the user's external ID in Keycloak and without it the Identity Provider linking will fail.
 
 **Step 2: Map externalId in SCIM provisioning**
 
-In the Entra Id, make sure that the objectId from Entra ID is mapped into the SCIM externalId field:
+In Entra ID, make sure that the `objectId` from Entra ID is mapped into the SCIM `externalId` field:
 
-1. Navigate to your **Enterprise Application** > **Provisioning** > **Attribute Mapping (Preview)** > **Provision Microsoft Entra ID Users**.
+1. Navigate to your **Enterprise Application > Provisioning > Attribute Mapping (Preview) > Provision Microsoft Entra ID Users**.
 2. Click **Add New Mapping**.
 3. Set:
-  - **Source attribute**: objectId
-  - **Target attribute**: externalId
+   - **Source attribute**: `objectId`
+   - **Target attribute**: `externalId`
 4. Click **Save**.
 
-This ensures that during SCIM provisioning, the Entra objectId is stored in Keycloak as the user’s externalId, which will later be used for identity linking.
+This ensures that during SCIM provisioning, the Entra `objectId` is stored in Keycloak as the user's `externalId`, which will later be used for identity linking.
 
 **Step 3: Configure Keycloak Identity Provider to Use Object ID**
 
-Next, configure your Entra ID Identity Provider in Keycloak to use the oid claim from the login token instead of the default sub claim (which is app-specific).
+Configure your Entra ID Identity Provider in Keycloak to use the `oid` claim from the login token instead of the default `sub` claim (which is app-specific).
 
 1. Navigate to **Identity Providers** > select your **Entra ID provider**.
-2. Go to the **Mappers tab**.
+2. Go to the **Mappers** tab.
 3. Click **Add Mapper**.
 4. Fill in the mapper details:
-   - **Name**: map_oid_as_brokerid (or any descriptive name)
+   - **Name**: `map_oid_as_brokerid` (or any descriptive name)
    - **Sync Mode**: Force
    - **Mapper Type**: Username Template Importer
-   - **Template**: ${CLAIM.oid}
+   - **Template**: `${CLAIM.oid}`
    - **Target**: BROKER_ID
 5. Click **Save**.
 
-This mapper tells Keycloak to use the Entra oid claim as the Broker ID, ensuring that the login user is matched correctly with the SCIM-provisioned user.
+This mapper tells Keycloak to use the Entra `oid` claim as the Broker ID, ensuring that the login user is matched correctly with the SCIM-provisioned user.
 
 **Step 4: Enable Identity Provider Linking in SCIM**
 
-Finally, instruct your SCIM server to automatically link users to the configured Identity Provider during provisioning:
+Add the following settings to your SCIM configuration:
 
-Add the following attribute to your SCIM configuration: 
+```
+SCIM_LINK_IDP=true
+```
 
-    SCIM_LINK_IDP=true
+If you want to link users to a realm-level identity provider, also add:
 
-In case you want to link user to a realm level identity provider, also add the following attribute:
+```
+SCIM_IDENTITY_PROVIDER_ALIAS=<your-idp-alias>
+```
 
-    SCIM_IDENTITY_PROVIDER_ALIAS=<your-idp-alias>
-
-This will ensure that when a user is provisioned via SCIM, a corresponding Identity Provider link is also created automatically based on the externalId / oid.
+This ensures that when a user is provisioned via SCIM, a corresponding Identity Provider link is created automatically based on the `externalId` / `oid`.
 
 ## SCIM-Managed Users
 
-By default, the SCIM server only exposes users who are explicitly assigned the scim-managed role within the realm. This ensures that only users intended to be managed through SCIM are returned or modifiable via SCIM API operations.
+By default, the SCIM server only exposes users who are explicitly assigned the `scim-managed` role within the realm. This ensures that only users intended to be managed through SCIM are returned or modifiable via SCIM API operations.
 
 This prevents accidental exposure or modification of users that were:
-   - created manually via the Keycloak admin UI
-   - imported from external identity providers
-   - or otherwise not intended to be managed through SCIM
+- created manually via the Keycloak admin UI
+- imported from external identity providers
+- or otherwise not intended to be managed through SCIM
 
-If you want to expose all users (i.e., bypass filtering), you can simply assign the scim-managed role to every user. This effectively disables the filter, making the SCIM behavior equivalent to an unfiltered list.
+If you want to expose all users (i.e., bypass filtering), you can simply assign the `scim-managed` role to every user. This effectively disables the filter, making the SCIM behavior equivalent to an unfiltered list.
 
 This role-based filtering applies to all SCIM operations, including:
-   - GET /Users
-   - PATCH /Users/{id}
-   - DELETE /Users/{id}
+- `GET /Users`
+- `PATCH /Users/{id}`
+- `DELETE /Users/{id}`
 
-Users without the scim-managed role will be invisible to SCIM clients — they won’t be listed, updated, or removed through SCIM.
+Users without the `scim-managed` role will be invisible to SCIM clients -- they won't be listed, updated, or removed through SCIM.
 
 This filtering mechanism is designed to improve safety, especially in complex deployments involving federated users, legacy accounts, or overlapping identity sources (such as Entra ID + local users).
 
-This design does mean that provisioning a user through SCIM who previously existed without the role may cause conflicts or provisioning failures if role assignment isn’t handled correctly. However, this is a deliberate design choice to provide fine-grained control over which users are SCIM-visible.
+This design does mean that provisioning a user through SCIM who previously existed without the role may cause conflicts or provisioning failures if role assignment isn't handled correctly. However, this is a deliberate design choice to provide fine-grained control over which users are SCIM-visible.
 
 ## License
 
 [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
-  
+
 ---
 
 <div id="metatavu-custom-footer"><div align="center">
     <img src="https://metatavu.fi/wp-content/uploads/2024/02/cropped-metatavu-favicon.jpg" alt="Organization Logo" width="100">
-    <p>© 2025 Metatavu. All rights reserved.</p>
+    <p>&copy; 2025 Metatavu. All rights reserved.</p>
     <p>
-        <a href="https://www.metatavu.fi">Website</a> | 
-        <a href="https://twitter.com/metatavu">Twitter</a> | 
+        <a href="https://www.metatavu.fi">Website</a> |
+        <a href="https://twitter.com/metatavu">Twitter</a> |
         <a href="https://fi.linkedin.com/company/metatavu">LinkedIn</a>
     </p>
 </div></div>

--- a/src/main/java/fi/metatavu/keycloak/scim/server/AbstractScimServer.java
+++ b/src/main/java/fi/metatavu/keycloak/scim/server/AbstractScimServer.java
@@ -7,6 +7,7 @@ import fi.metatavu.keycloak.scim.server.consts.ScimRoles;
 import fi.metatavu.keycloak.scim.server.groups.GroupsController;
 import fi.metatavu.keycloak.scim.server.metadata.MetadataController;
 import fi.metatavu.keycloak.scim.server.users.UsersController;
+import java.util.Base64;
 import jakarta.mail.internet.AddressException;
 import jakarta.mail.internet.InternetAddress;
 import jakarta.ws.rs.ForbiddenException;
@@ -105,8 +106,36 @@ public abstract class AbstractScimServer <T extends ScimContext> implements Scim
 
         if (config.getAuthenticationMode() == ScimConfig.AuthenticationMode.KEYCLOAK) {
             keycloakAuthentication(context, session, realm, headers);
+        } else if (authorization.startsWith("Basic ")) {
+            basicAuthentication(config, authorization, session);
         } else {
-            externalAuthentication(config, extractToken(authorization), session);
+            externalAuthentication(config, extractBearerToken(authorization), session);
+        }
+    }
+
+    private void basicAuthentication(ScimConfig config, String authorization, KeycloakSession session) {
+        String basicAuthUsername = config.getBasicAuthUsername();
+        String basicAuthPassword = config.getBasicAuthPassword();
+
+        if (basicAuthUsername == null || basicAuthUsername.isBlank() || basicAuthPassword == null || basicAuthPassword.isBlank()) {
+            logger.warn("Basic auth credentials received but Basic auth is not configured");
+            throw new NotAuthorizedException("Basic auth is not configured");
+        }
+
+        String encoded = authorization.substring("Basic ".length()).trim();
+        String decoded;
+        try {
+            decoded = new String(Base64.getDecoder().decode(encoded));
+        } catch (IllegalArgumentException e) {
+            logger.warn("Invalid Base64 in Basic auth header");
+            throw new NotAuthorizedException("Invalid Basic auth header");
+        }
+
+        Verifier verifier = VerifierFactory.buildBasicAuth(config, session);
+
+        if (!verifier.verify(decoded)) {
+            logger.warn("Basic auth verification failed");
+            throw new NotAuthorizedException("Basic auth verification failed");
         }
     }
 
@@ -153,7 +182,7 @@ public abstract class AbstractScimServer <T extends ScimContext> implements Scim
         }
     }
 
-    private String extractToken(String authorization) {
+    private String extractBearerToken(String authorization) {
         if (authorization.startsWith("Bearer ")) {
             return authorization.substring("Bearer ".length()).trim();
         } else {

--- a/src/main/java/fi/metatavu/keycloak/scim/server/authentication/BasicAuthVerifier.java
+++ b/src/main/java/fi/metatavu/keycloak/scim/server/authentication/BasicAuthVerifier.java
@@ -1,0 +1,85 @@
+package fi.metatavu.keycloak.scim.server.authentication;
+
+import java.util.List;
+import java.util.Optional;
+import org.jboss.logging.Logger;
+import org.keycloak.common.util.MultivaluedHashMap;
+import org.keycloak.credential.hash.PasswordHashProvider;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.credential.PasswordCredentialModel;
+
+/**
+ * Verifies Basic Auth credentials (username and password)
+ */
+public class BasicAuthVerifier implements Verifier {
+
+    private static final Logger logger = Logger.getLogger(BasicAuthVerifier.class);
+
+    private final KeycloakSession session;
+    private final String expectedUsername;
+    private final String hashedPassword;
+
+    /**
+     * Constructor
+     *
+     * @param session Keycloak Session
+     * @param expectedUsername expected username
+     * @param hashedPassword password hash in PHC String format
+     */
+    public BasicAuthVerifier(KeycloakSession session, String expectedUsername, String hashedPassword) {
+        this.session = session;
+        this.expectedUsername = expectedUsername;
+        this.hashedPassword = hashedPassword;
+    }
+
+    /**
+     * Verifies the given credentials.
+     *
+     * @param credentials username:password string (already Base64-decoded)
+     * @return true if the credentials are valid, false otherwise
+     */
+    @Override
+    public boolean verify(String credentials) {
+        int colonIndex = credentials.indexOf(':');
+        if (colonIndex < 0) {
+            logger.warn("Basic auth credentials missing colon separator");
+            return false;
+        }
+
+        String username = credentials.substring(0, colonIndex);
+        String password = credentials.substring(colonIndex + 1);
+
+        if (!expectedUsername.equals(username)) {
+            logger.warn("Basic auth username mismatch");
+            return false;
+        }
+
+        if (hashedPassword == null || hashedPassword.isBlank()) {
+            logger.warn("Basic auth password hash is null or blank");
+            return false;
+        }
+
+        PasswordCredentialModel model = PhcStringUtils.fromPHCString(hashedPassword);
+        String algorithm = model.getPasswordCredentialData().getAlgorithm();
+        MultivaluedHashMap<String, String> additionalParameters = model.getPasswordCredentialData()
+            .getAdditionalParameters();
+        String type = Optional.ofNullable(additionalParameters)
+            .map(params -> params.get("type"))
+            .filter(typeList -> !typeList.isEmpty())
+            .map(List::getFirst)
+            .orElse("");
+        PasswordHashProvider hashProvider = session.getProvider(PasswordHashProvider.class, algorithm.replace(type, ""));
+
+        if (hashProvider == null) {
+            throw new RuntimeException(
+                String.format(
+                    "Hash provider not found with hash algorithm: %s. Only official Keycloak hash algorithms are expected (see README.md).",
+                    algorithm
+                )
+            );
+        }
+
+        return hashProvider.verify(password, model);
+    }
+
+}

--- a/src/main/java/fi/metatavu/keycloak/scim/server/authentication/VerifierFactory.java
+++ b/src/main/java/fi/metatavu/keycloak/scim/server/authentication/VerifierFactory.java
@@ -15,7 +15,7 @@ public class VerifierFactory {
     private VerifierFactory() {}
 
     /**
-     * Builds the verifier based on the ScimConfig
+     * Builds a verifier for Bearer token authentication based on the ScimConfig
      */
     public static Verifier build(ScimConfig config, KeycloakSession session) {
         if (config.getAuthenticationMode() != AuthenticationMode.EXTERNAL) {
@@ -30,5 +30,15 @@ public class VerifierFactory {
         } else {
             return new ExternalSharedSecretVerifier(session, sharedSecret);
         }
+    }
+
+    /**
+     * Builds a verifier for Basic Auth authentication based on the ScimConfig
+     */
+    public static Verifier buildBasicAuth(ScimConfig config, KeycloakSession session) {
+        if (config.getAuthenticationMode() != AuthenticationMode.EXTERNAL) {
+            throw new IllegalArgumentException("Authentication mode must be EXTERNAL");
+        }
+        return new BasicAuthVerifier(session, config.getBasicAuthUsername(), config.getBasicAuthPassword());
     }
 }

--- a/src/main/java/fi/metatavu/keycloak/scim/server/config/ScimConfig.java
+++ b/src/main/java/fi/metatavu/keycloak/scim/server/config/ScimConfig.java
@@ -75,4 +75,18 @@ public interface ScimConfig {
      * @return true if email should be used as username
      */
     boolean getEmailAsUsername();
+
+    /**
+     * Gets the basic auth username (if using EXTERNAL mode with Basic auth)
+     *
+     * @return basic auth username or null if not configured
+     */
+    String getBasicAuthUsername();
+
+    /**
+     * Gets the basic auth password in PHC String format (if using EXTERNAL mode with Basic auth)
+     *
+     * @return basic auth password hash or null if not configured
+     */
+    String getBasicAuthPassword();
 }

--- a/src/main/java/fi/metatavu/keycloak/scim/server/organization/OrganizationScimConfig.java
+++ b/src/main/java/fi/metatavu/keycloak/scim/server/organization/OrganizationScimConfig.java
@@ -22,6 +22,8 @@ public class OrganizationScimConfig implements ScimConfig {
     public static final String SCIM_EXTERNAL_ISSUER = "SCIM_EXTERNAL_ISSUER";
     public static final String SCIM_AUTHENTICATION_MODE = "SCIM_AUTHENTICATION_MODE";
     public static final String SCIM_EMAIL_AS_USERNAME = "SCIM_EMAIL_AS_USERNAME";
+    public static final String SCIM_BASIC_AUTH_USERNAME = "SCIM_BASIC_AUTH_USERNAME";
+    public static final String SCIM_BASIC_AUTH_PASSWORD = "SCIM_BASIC_AUTH_PASSWORD";
 
     private final OrganizationModel organization;
 
@@ -40,9 +42,20 @@ public class OrganizationScimConfig implements ScimConfig {
         logger.debugf("Organization SCIM authentication mode: %s", mode);
 
         boolean isSharedSecretPresent = getSharedSecret() != null && !getSharedSecret().isBlank();
+        boolean isBasicAuthUsernamePresent = getBasicAuthUsername() != null && !getBasicAuthUsername().isBlank();
+        boolean isBasicAuthPasswordPresent = getBasicAuthPassword() != null && !getBasicAuthPassword().isBlank();
 
         if (mode == AuthenticationMode.EXTERNAL) {
-            if (!isSharedSecretPresent) {
+            if (isBasicAuthUsernamePresent || isBasicAuthPasswordPresent) {
+                if (!isBasicAuthUsernamePresent) {
+                    logger.warnf("Organization SCIM config invalid: %s is not set", SCIM_BASIC_AUTH_USERNAME);
+                    throw new ConfigurationError(SCIM_BASIC_AUTH_USERNAME + " must be set when " + SCIM_BASIC_AUTH_PASSWORD + " is set");
+                }
+                if (!isBasicAuthPasswordPresent) {
+                    logger.warnf("Organization SCIM config invalid: %s is not set", SCIM_BASIC_AUTH_PASSWORD);
+                    throw new ConfigurationError(SCIM_BASIC_AUTH_PASSWORD + " must be set when " + SCIM_BASIC_AUTH_USERNAME + " is set");
+                }
+            } else if (!isSharedSecretPresent) {
                 if (getExternalIssuer() == null) {
                     logger.warnf("Organization SCIM config invalid: %s is not set", SCIM_EXTERNAL_ISSUER);
                     throw new ConfigurationError(SCIM_EXTERNAL_ISSUER + " is not set");
@@ -113,6 +126,16 @@ public class OrganizationScimConfig implements ScimConfig {
     @Override
     public boolean getEmailAsUsername() {
         return "true".equalsIgnoreCase(getAttribute(SCIM_EMAIL_AS_USERNAME));
+    }
+
+    @Override
+    public String getBasicAuthUsername() {
+        return getAttribute(SCIM_BASIC_AUTH_USERNAME);
+    }
+
+    @Override
+    public String getBasicAuthPassword() {
+        return getAttribute(SCIM_BASIC_AUTH_PASSWORD);
     }
 
     /**

--- a/src/main/java/fi/metatavu/keycloak/scim/server/realm/RealmScimConfig.java
+++ b/src/main/java/fi/metatavu/keycloak/scim/server/realm/RealmScimConfig.java
@@ -24,6 +24,8 @@ public class RealmScimConfig implements ScimConfig {
     public static final String SCIM_LINK_IDP = "scim.link.idp";
     public static final String SCIM_IDENTITY_PROVIDER_ALIAS = "scim.identity.provider.alias";
     public static final String SCIM_EMAIL_AS_USERNAME = "scim.email.as.username";
+    public static final String SCIM_BASIC_AUTH_USERNAME = "scim.basic.auth.username";
+    public static final String SCIM_BASIC_AUTH_PASSWORD = "scim.basic.auth.password";
     private final Config config;
     private final RealmModel realm;
 
@@ -48,21 +50,34 @@ public class RealmScimConfig implements ScimConfig {
         logger.debugf("Realm SCIM authentication mode: %s", mode);
 
         boolean isSharedSecretPresent = getSharedSecret() != null && !getSharedSecret().isBlank();
+        boolean isBasicAuthUsernamePresent = getBasicAuthUsername() != null && !getBasicAuthUsername().isBlank();
+        boolean isBasicAuthPasswordPresent = getBasicAuthPassword() != null && !getBasicAuthPassword().isBlank();
 
-        if (mode == AuthenticationMode.EXTERNAL && !isSharedSecretPresent) {
-            if (getExternalIssuer() == null) {
-                logger.warn("Realm SCIM config invalid: SCIM_EXTERNAL_ISSUER is not set");
-                throw new ConfigurationError("SCIM_EXTERNAL_ISSUER is not set");
-            }
+        if (mode == AuthenticationMode.EXTERNAL) {
+            if (isBasicAuthUsernamePresent || isBasicAuthPasswordPresent) {
+                if (!isBasicAuthUsernamePresent) {
+                    logger.warn("Realm SCIM config invalid: SCIM_BASIC_AUTH_USERNAME is not set");
+                    throw new ConfigurationError("SCIM_BASIC_AUTH_USERNAME must be set when SCIM_BASIC_AUTH_PASSWORD is set");
+                }
+                if (!isBasicAuthPasswordPresent) {
+                    logger.warn("Realm SCIM config invalid: SCIM_BASIC_AUTH_PASSWORD is not set");
+                    throw new ConfigurationError("SCIM_BASIC_AUTH_PASSWORD must be set when SCIM_BASIC_AUTH_USERNAME is set");
+                }
+            } else if (!isSharedSecretPresent) {
+                if (getExternalIssuer() == null) {
+                    logger.warn("Realm SCIM config invalid: SCIM_EXTERNAL_ISSUER is not set");
+                    throw new ConfigurationError("SCIM_EXTERNAL_ISSUER is not set");
+                }
 
-            if (getExternalJwksUri() == null) {
-                logger.warn("Realm SCIM config invalid: SCIM_EXTERNAL_JWKS_URI is not set");
-                throw new ConfigurationError("SCIM_EXTERNAL_JWKS_URI is not set");
-            }
+                if (getExternalJwksUri() == null) {
+                    logger.warn("Realm SCIM config invalid: SCIM_EXTERNAL_JWKS_URI is not set");
+                    throw new ConfigurationError("SCIM_EXTERNAL_JWKS_URI is not set");
+                }
 
-            if (getExternalAudience() == null) {
-                logger.warn("Realm SCIM config invalid: SCIM_EXTERNAL_AUDIENCE is not set");
-                throw new ConfigurationError("SCIM_EXTERNAL_AUDIENCE is not set");
+                if (getExternalAudience() == null) {
+                    logger.warn("Realm SCIM config invalid: SCIM_EXTERNAL_AUDIENCE is not set");
+                    throw new ConfigurationError("SCIM_EXTERNAL_AUDIENCE is not set");
+                }
             }
         }
 
@@ -152,6 +167,20 @@ public class RealmScimConfig implements ScimConfig {
             .map(Boolean::parseBoolean)
             .or(() -> config.getOptionalValue(SCIM_EMAIL_AS_USERNAME, Boolean.class))
             .orElse(false);
+    }
+
+    @Override
+    public String getBasicAuthUsername() {
+        return readRealmAttribute(SCIM_BASIC_AUTH_USERNAME)
+                .or(() -> config.getOptionalValue(SCIM_BASIC_AUTH_USERNAME, String.class))
+                .orElse(null);
+    }
+
+    @Override
+    public String getBasicAuthPassword() {
+        return readRealmAttribute(SCIM_BASIC_AUTH_PASSWORD)
+                .or(() -> config.getOptionalValue(SCIM_BASIC_AUTH_PASSWORD, String.class))
+                .orElse(null);
     }
 
     /**

--- a/src/test/java/fi/metatavu/keycloak/scim/server/test/ScimClient.java
+++ b/src/test/java/fi/metatavu/keycloak/scim/server/test/ScimClient.java
@@ -8,6 +8,7 @@ import fi.metatavu.keycloak.scim.server.test.client.api.UsersApi;
 import fi.metatavu.keycloak.scim.server.test.client.model.*;
 
 import java.net.URI;
+import java.util.Base64;
 
 /**
  * SCIM client
@@ -15,10 +16,10 @@ import java.net.URI;
 public class ScimClient {
 
     private final URI scimUri;
-    private final String accessToken;
+    private final String authorizationHeader;
 
     /**
-     * Constructor
+     * Constructor for Bearer token authentication
      *
      * @param scimUri SCIM URI
      * @param accessToken access token
@@ -28,7 +29,23 @@ public class ScimClient {
         String accessToken
     ) {
         this.scimUri = scimUri;
-        this.accessToken = accessToken;
+        this.authorizationHeader = "Bearer " + accessToken;
+    }
+
+    /**
+     * Constructor for Basic authentication
+     *
+     * @param scimUri SCIM URI
+     * @param username username
+     * @param password password
+     */
+    public ScimClient(
+        URI scimUri,
+        String username,
+        String password
+    ) {
+        this.scimUri = scimUri;
+        this.authorizationHeader = "Basic " + Base64.getEncoder().encodeToString((username + ":" + password).getBytes());
     }
 
     /**
@@ -246,7 +263,7 @@ public class ScimClient {
         result.setHost(scimUri.getHost());
         result.setScheme(scimUri.getScheme());
         result.setPort(scimUri.getPort());
-        result.setRequestInterceptor(builder -> builder.header("Authorization", "Bearer " + accessToken));
+        result.setRequestInterceptor(builder -> builder.header("Authorization", authorizationHeader));
         return result;
     }
 }

--- a/src/test/java/fi/metatavu/keycloak/scim/server/test/tests/functional/RealmBasicAuthTestsIT.java
+++ b/src/test/java/fi/metatavu/keycloak/scim/server/test/tests/functional/RealmBasicAuthTestsIT.java
@@ -1,0 +1,56 @@
+package fi.metatavu.keycloak.scim.server.test.tests.functional;
+
+import dasniko.testcontainers.keycloak.KeycloakContainer;
+import fi.metatavu.keycloak.scim.server.test.ScimClient;
+import fi.metatavu.keycloak.scim.server.test.client.ApiException;
+import fi.metatavu.keycloak.scim.server.test.tests.AbstractRealmScimTest;
+import fi.metatavu.keycloak.scim.server.test.utils.KeycloakTestUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@Testcontainers
+public class RealmBasicAuthTestsIT extends AbstractRealmScimTest {
+
+    @Container
+    protected static final KeycloakContainer keycloakContainer = KeycloakTestUtils.createBasicAuthRealmKeycloakContainer(network);
+
+    @Override
+    protected KeycloakContainer getKeycloakContainer() {
+        return keycloakContainer;
+    }
+
+    @AfterAll
+    static void tearDown() {
+        KeycloakTestUtils.stopKeycloakContainer(keycloakContainer);
+    }
+
+    @Test
+    void testGetResourceTypesWithBasicAuth() throws ApiException {
+        ScimClient scimClient = new ScimClient(getScimUri(), "scim-admin", "tutu");
+        scimClient.getResourceTypes();
+    }
+
+    @Test
+    void testErrorGetResourceTypesWithWrongPassword() {
+        assertThrows(
+            ApiException.class, () -> {
+                ScimClient scimClient = new ScimClient(getScimUri(), "scim-admin", "wrong-password");
+                scimClient.getResourceTypes();
+            }
+        );
+    }
+
+    @Test
+    void testErrorGetResourceTypesWithWrongUsername() {
+        assertThrows(
+            ApiException.class, () -> {
+                ScimClient scimClient = new ScimClient(getScimUri(), "wrong-user", "tutu");
+                scimClient.getResourceTypes();
+            }
+        );
+    }
+}

--- a/src/test/java/fi/metatavu/keycloak/scim/server/test/utils/KeycloakTestUtils.java
+++ b/src/test/java/fi/metatavu/keycloak/scim/server/test/utils/KeycloakTestUtils.java
@@ -139,6 +139,24 @@ public class KeycloakTestUtils {
     }
 
     @SuppressWarnings("resource")
+    public static KeycloakContainer createBasicAuthRealmKeycloakContainer(Network network) {
+        return new KeycloakContainer(KeycloakTestUtils.getKeycloakImage())
+                .withNetwork(network)
+                .withNetworkAliases("scim-keycloak")
+                .withEnv("SCIM_AUTHENTICATION_MODE", "EXTERNAL")
+                .withEnv("SCIM_BASIC_AUTH_USERNAME", "scim-admin")
+                .withEnv("SCIM_BASIC_AUTH_PASSWORD", "$argon2id$v=19$m=16,t=2,p=1$UUppcFAwQUp0SkQwVGZudQ$j5RwfEzt3Gvwpbqp0VDcJg") // tutu with argon2id
+                .withProviderLibsFrom(KeycloakTestUtils.getBuildProviders())
+                .withRealmImportFile("kc-test.json")
+                .withEnv("JAVA_OPTS_APPEND", "-javaagent:/jacoco-agent/org.jacoco.agent-runtime.jar=destfile=/tmp/jacoco.exec")
+                .withCopyFileToContainer(
+                        MountableFile.forHostPath(getJacocoAgentPath()),
+                        "/jacoco-agent/org.jacoco.agent-runtime.jar"
+                )
+                .withLogConsumer(outputFrame -> System.out.printf("KEYCLOAK: %s", outputFrame.getUtf8String()));
+    }
+
+    @SuppressWarnings("resource")
     public static KeycloakContainer createNoAuthRealmKeycloakContainer(Network network) {
         return new KeycloakContainer(KeycloakTestUtils.getKeycloakImage())
                 .withNetwork(network)


### PR DESCRIPTION
This PR adds HTTP Basic Authentication support to the SCIM server, enabling compatibility with Okta's SCIM provisioning (which supports Basic Auth, HTTP Header, and OAuth2). Of the three, only Basic Auth required code changes — HTTP Header already works via the existing shared secret mechanism, and OAuth2 works by pointing Okta at Keycloak's token endpoint with the existing JWT/JWKS validation.

Changes:
  - New `BasicAuthVerifier` that validates Base64-decoded username:password credentials against configured values (password stored as a PHC-format hash, same pattern as the existing shared secret verifier)
  - Updated `AbstractScimServer` to detect Basic vs Bearer authorization schemes and route accordingly
  - Added `SCIM_BASIC_AUTH_USERNAME` and `SCIM_BASIC_AUTH_PASSWORD` config fields at all three levels (instance, realm, organization)
  - Integration tests for Basic Auth success and failure cases
  - Restructured `README` with a table of contents, dedicated sections per auth method, and vendor-specific setup guides for both Entra ID and Okta