### PR TITLE
Handle path-less PatchOp shape (Okta Deactivate User)

### DIFF
--- a/src/main/java/fi/metatavu/keycloak/scim/server/users/UsersController.java
+++ b/src/main/java/fi/metatavu/keycloak/scim/server/users/UsersController.java
@@ -302,36 +302,32 @@ public class UsersController extends AbstractController {
                 throw new UnsupportedPatchOperation("Unsupported patch operation: " + operation.getOp());
             }
 
-            UserAttribute<?> userAttribute = userAttributes.findByScimPath(operation.getPath());
+            String path = operation.getPath();
             Object value = operation.getValue();
 
-            if (userAttribute == null) {
-                throw new UnsupportedUserPath("Unsupported attribute: " + operation.getPath());
-            }
-
-            switch (op) {
-                case REPLACE, ADD -> {
-                    switch (value) {
-                        case null:
-                            logger.warn("Value is null for patch operation: " + op);
-                            break;
-                        case String s when userAttribute instanceof StringUserAttribute:
-                            ((StringUserAttribute) userAttribute).write(existing, s);
-                            break;
-                        case String s when userAttribute instanceof BooleanUserAttribute:
-                            ((BooleanUserAttribute) userAttribute).write(existing, Boolean.parseBoolean(s));
-                            break;
-                        case Boolean b when userAttribute instanceof BooleanUserAttribute:
-                            ((BooleanUserAttribute) userAttribute).write(existing, b);
-                            break;
-                        default:
-                            logger.warn("Unsupported value type for patch operation: " + value.getClass() + " for SCIM path " + userAttribute.getScimPath());
-                            break;
-                    }
-
+            // RFC 7644 §3.5.2: when "path" is omitted, "value" carries a map of
+            // attribute -> value to apply to the resource. Okta's Deactivate User
+            // emits this shape: {"op":"replace","value":{"active":false}}.
+            if (path == null) {
+                if (!(value instanceof Map<?, ?> valueMap)) {
+                    throw new UnsupportedUserPath("PatchOp without 'path' requires a map-valued 'value'");
                 }
-                case REMOVE -> userAttribute.write(existing, null);
+                for (Map.Entry<?, ?> entry : valueMap.entrySet()) {
+                    String attrPath = String.valueOf(entry.getKey());
+                    UserAttribute<?> ua = userAttributes.findByScimPath(attrPath);
+                    if (ua == null) {
+                        throw new UnsupportedUserPath("Unsupported attribute: " + attrPath);
+                    }
+                    applyPatchValue(op, ua, existing, entry.getValue());
+                }
+                continue;
             }
+
+            UserAttribute<?> userAttribute = userAttributes.findByScimPath(path);
+            if (userAttribute == null) {
+                throw new UnsupportedUserPath("Unsupported attribute: " + path);
+            }
+            applyPatchValue(op, userAttribute, existing, value);
         }
 
         dispatchUserUpdateEvent(scimContext, existing);
@@ -349,6 +345,47 @@ public class UsersController extends AbstractController {
 
 
         return patchedUser;
+    }
+
+    /**
+     * Apply a single PATCH operation (REPLACE/ADD/REMOVE) against one
+     * resolved user attribute. Extracted so the path-less PatchOp shape
+     * (RFC 7644 §3.5.2, map-valued "value") and the with-path shape share
+     * the same write semantics.
+     *
+     * @param op       patch operation kind
+     * @param attr     resolved user attribute target
+     * @param existing user being patched
+     * @param value    raw operation value
+     */
+    private void applyPatchValue(
+        PatchOperation op,
+        UserAttribute<?> attr,
+        UserModel existing,
+        Object value
+    ) {
+        switch (op) {
+            case REPLACE, ADD -> {
+                switch (value) {
+                    case null:
+                        logger.warn("Value is null for patch operation: " + op);
+                        break;
+                    case String s when attr instanceof StringUserAttribute:
+                        ((StringUserAttribute) attr).write(existing, s);
+                        break;
+                    case String s when attr instanceof BooleanUserAttribute:
+                        ((BooleanUserAttribute) attr).write(existing, Boolean.parseBoolean(s));
+                        break;
+                    case Boolean b when attr instanceof BooleanUserAttribute:
+                        ((BooleanUserAttribute) attr).write(existing, b);
+                        break;
+                    default:
+                        logger.warn("Unsupported value type for patch operation: " + value.getClass() + " for SCIM path " + attr.getScimPath());
+                        break;
+                }
+            }
+            case REMOVE -> attr.write(existing, null);
+        }
     }
 
     /**

--- a/src/test/java/fi/metatavu/keycloak/scim/server/test/tests/functional/RealmUserPatchTestsIT.java
+++ b/src/test/java/fi/metatavu/keycloak/scim/server/test/tests/functional/RealmUserPatchTestsIT.java
@@ -15,6 +15,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -184,6 +185,59 @@ public class RealmUserPatchTestsIT extends AbstractInternalAuthRealmScimTest {
             created.getId(),
             OperationType.UPDATE
         );
+
+        // Cleanup
+        deleteRealmUser(TestConsts.TEST_REALM, created.getId());
+    }
+
+    /**
+     * Okta's Deactivate User action emits a PATCH without a top-level "path",
+     * carrying the attribute change inside a map-valued "value" (RFC 7644
+     * §3.5.2). This test covers that shape; the other tests only cover the
+     * with-path form.
+     */
+    @Test
+    void testDeactivateUserPathLessPatchOp() throws ApiException {
+        ScimClient scimClient = getAuthenticatedScimClient();
+
+        // Create an active user
+        User user = new User();
+        user.setUserName("patch-pathless-user");
+        user.setActive(true);
+        user.setSchemas(List.of("urn:ietf:params:scim:schemas:core:2.0:User"));
+
+        User created = scimClient.createUser(user);
+        assertNotNull(created);
+        assertTrue(created.getActive());
+
+        // Okta shape: no "path", value is a map {"active": false}
+        User deactivated = scimClient.patchUser(created.getId(), new PatchRequest()
+            .schemas(List.of("urn:ietf:params:scim:api:messages:2.0:PatchOp"))
+            .operations(List.of(
+                new PatchRequestOperationsInner()
+                    .op("replace")
+                    .value(Map.of("active", Boolean.FALSE))
+            )));
+
+        assertNotNull(deactivated);
+        assertNotNull(deactivated.getActive());
+        assertFalse(deactivated.getActive());
+
+        UserRepresentation deactivatedRealmUser = findRealmUser(TestConsts.TEST_REALM, created.getId());
+        assertNotNull(deactivatedRealmUser);
+        assertFalse(deactivatedRealmUser.isEnabled());
+
+        // Re-activate via the same shape to confirm the code path is symmetric
+        User activated = scimClient.patchUser(created.getId(), new PatchRequest()
+            .schemas(List.of("urn:ietf:params:scim:api:messages:2.0:PatchOp"))
+            .operations(List.of(
+                new PatchRequestOperationsInner()
+                    .op("replace")
+                    .value(Map.of("active", Boolean.TRUE))
+            )));
+
+        assertNotNull(activated);
+        assertTrue(activated.getActive());
 
         // Cleanup
         deleteRealmUser(TestConsts.TEST_REALM, created.getId());


### PR DESCRIPTION
Fixes #95.

## Problem

`UsersController.patchUser` (v1.5.0) throws `UnsupportedUserPath: Unsupported attribute: null` for PATCH requests that omit the top-level `path` and put the attribute change inside a map-valued `value`. This is the exact shape Okta's Deactivate User flow emits:

```json
{"Operations":[{"op":"replace","value":{"active":false}}]}
```

Valid per [RFC 7644 §3.5.2.1 and §3.5.2.3](https://datatracker.ietf.org/doc/html/rfc7644#section-3.5.2). The existing code only handled the with-path form (`path: "active", value: false`), so any IdP that defaults to the path-less shape (Okta, and some Azure AD configurations) cannot deactivate users.

## Fix

When `operation.getPath()` is `null`, iterate the map-valued `value` and apply each `(attribute, value)` pair, sharing the write logic with the with-path branch via a new private `applyPatchValue` helper.

## Test

Added `RealmUserPatchTestsIT#testDeactivateUserPathLessPatchOp` covering both deactivate and reactivate through the path-less shape. Existing tests for the with-path shape continue to pass (the helper extraction is a pure refactor on that path).

## Repro context

Reproduced in production with Okta's built-in `SCIM 2.0 Test App (Header Auth)` against Keycloak 26.5.6 with v1.5.0 installed. After this patch, deactivate + reactivate propagate cleanly from Okta to Keycloak (`enabled: true/false` in the realm user representation).

Happy to iterate on naming / helper placement, let me know.