### PR TITLE
added workflow to publish to maven central

### DIFF
--- a/.github/workflows/publish-maven-central.yaml
+++ b/.github/workflows/publish-maven-central.yaml
@@ -1,0 +1,66 @@
+name: Publish to Maven Central
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (e.g. 1.5.0). Leave blank to use gradle.properties (stripping -SNAPSHOT).'
+        required: false
+        type: string
+
+jobs:
+  publish:
+    environment: master
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Resolve publish version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            VERSION="${{ github.event.release.tag_name }}"
+            VERSION="${VERSION#v}"
+          elif [ -n "${{ inputs.version }}" ]; then
+            VERSION="${{ inputs.version }}"
+          else
+            VERSION=$(grep '^version=' gradle.properties | cut -d'=' -f2)
+            VERSION="${VERSION%-SNAPSHOT}"
+          fi
+          if [ -z "$VERSION" ]; then
+            echo "Could not resolve a version to publish" >&2
+            exit 1
+          fi
+          echo "Publishing version: $VERSION"
+          echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
+          # Make the build use the resolved version regardless of trigger
+          sed -i "s/^version=.*/version=$VERSION/" gradle.properties
+
+      - name: Build artifacts
+        run: ./gradlew clean build -x test --no-configuration-cache
+        env:
+          USERNAME: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish to Maven Central
+        run: ./gradlew publishAndReleaseToMavenCentral --no-configuration-cache --stacktrace
+        env:
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.MAVEN_GPG_KEY_ID }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.MAVEN_GPG_PASSPHRASE }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,7 @@
 import java.util.*
+import com.vanniktech.maven.publish.JavaLibrary
+import com.vanniktech.maven.publish.JavadocJar
+import com.vanniktech.maven.publish.SonatypeHost
 import org.openapitools.generator.gradle.plugin.tasks.GenerateTask
 
 abstract class FixAdditionalPropertyModels : DefaultTask() {
@@ -24,9 +27,11 @@ abstract class FixAdditionalPropertyModels : DefaultTask() {
 plugins {
     `java-library`
     `maven-publish`
+    signing
     jacoco
     id("org.openapi.generator") version "7.2.0"
     id("org.sonarqube") version "6.2.0.5505"
+    id("com.vanniktech.maven.publish") version "0.30.0"
 }
 
 repositories {
@@ -248,6 +253,43 @@ tasks.register("nextSnapshotVersion") {
     }
 }
 
+mavenPublishing {
+    configure(JavaLibrary(javadocJar = JavadocJar.Javadoc(), sourcesJar = true))
+
+    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL, automaticRelease = true)
+
+    coordinates(project.group.toString(), "keycloak-scim-server", project.version.toString())
+
+    pom {
+        name.set("Keycloak SCIM Server")
+        description.set("SCIM 2.0 server extension for Keycloak")
+        inceptionYear.set("2024")
+        url.set("https://github.com/Metatavu/keycloak-scim-server")
+
+        licenses {
+            license {
+                name.set("The Apache License, Version 2.0")
+                url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+                distribution.set("repo")
+            }
+        }
+
+        developers {
+            developer {
+                id.set("Metatavu")
+                name.set("Metatavu Oy")
+                url.set("https://github.com/Metatavu/")
+            }
+        }
+
+        scm {
+            url.set("https://github.com/Metatavu/keycloak-scim-server")
+            connection.set("scm:git:git://github.com/Metatavu/keycloak-scim-server.git")
+            developerConnection.set("scm:git:ssh://git@github.com/Metatavu/keycloak-scim-server.git")
+        }
+    }
+}
+
 publishing {
     repositories {
         maven {
@@ -259,10 +301,16 @@ publishing {
             }
         }
     }
-    publications {
-        register<MavenPublication>("gpr") {
-            artifact(tasks["jar"])
-        }
+}
+
+signing {
+    val signingKey: String? = providers.environmentVariable("ORG_GRADLE_PROJECT_signingInMemoryKey")
+        .orElse(providers.gradleProperty("signingInMemoryKey")).orNull
+    val signingPassword: String? = providers.environmentVariable("ORG_GRADLE_PROJECT_signingInMemoryKeyPassword")
+        .orElse(providers.gradleProperty("signingInMemoryKeyPassword")).orNull
+    if (signingKey != null && signingPassword != null) {
+        useInMemoryPgpKeys(signingKey, signingPassword)
+        sign(publishing.publications)
     }
 }
 


### PR DESCRIPTION
## Maven Central Publishing Setup

Fixes #21 

Adds a GitHub Actions workflow and Gradle config to publish the jar to Maven Central via the new Central Portal (OSSRH was retired on 2025-06-30).

### Files changed
  - **`build.gradle.kts`** — added the `com.vanniktech.maven.publish` plugin (v0.30.0), full POM metadata, conditional in-memory PGP signing, and   Central Portal config.
  - **`.github/workflows/publish-maven-central.yaml`** — new workflow that triggers on `release: published` (and `workflow_dispatch`), runs `./gradlew publishAndReleaseToMavenCentral` to bundle the staging dir and upload it through the Central Portal API with auto-release.

### Key design choices
  - Used `com.vanniktech.maven.publish` — Sonatype still has no official Gradle plugin for the Central Portal, and this is the most widely used community plugin.
  - `SonatypeHost.CENTRAL_PORTAL` + `automaticRelease = true` so deployments don't sit pending manual approval at central.sonatype.com.
  - Signing is **conditional** on env vars being present — this prevents the existing `master-publish-docker-image.yaml` workflow (which runs the broader `./gradlew publish`) from failing when GPG keys aren't available. Verified via `--dry-run` that the existing workflow still works (Maven Central tasks just write to a local staging dir without creds).
  - `--no-configuration-cache` on the publish step since the project has config cache enabled globally and signing tasks don't always play well with it.

### Required GitHub Actions secrets

| Secret | What it is | How to get it |
|---|---|---|
| `MAVEN_CENTRAL_USERNAME` | User token **username** (not portal login) | central.sonatype.com → avatar → **View Account** → **Generate User Token** |
| `MAVEN_CENTRAL_PASSWORD` | User token **password** | Same screen as above (shown only once) |
| `MAVEN_GPG_PRIVATE_KEY` | ASCII-armored GPG private key | `gpg --export-secret-keys --armor <KEY_ID>` — paste the entire `-----BEGIN PGP PRIVATE KEY BLOCK-----` block |
| `MAVEN_GPG_KEY_ID` | Last 8 hex chars of the GPG key ID | `gpg --list-secret-keys --keyid-format=short` |
| `MAVEN_GPG_PASSPHRASE` | Passphrase protecting the GPG key | The one set when generating the key |

`GITHUB_TOKEN` is auto-provided.

### One-time prerequisites outside the repo
1. **Register & verify the namespace** at central.sonatype.com. The current group `fi.metatavu.keycloak.scim.server` requires control of `fi.metatavu`.
2. **Publish the GPG public key** so Central can verify signatures:
```bash
     gpg --keyserver keyserver.ubuntu.com --send-keys <KEY_ID>
     gpg --keyserver keys.openpgp.org --send-keys <KEY_ID>
```
3. Release flow: when a GitHub Release is published (already produced by `master-publish-docker-image.yaml`), this workflow fires automatically and uses the tag (with leading v stripped) as the version. Manual runs are also supported via workflow_dispatch.
