### PR TITLE
fix: guard null email in group membership leave admin event

### DIFF
--- a/src/main/java/fi/metatavu/keycloak/scim/server/groups/GroupsController.java
+++ b/src/main/java/fi/metatavu/keycloak/scim/server/groups/GroupsController.java
@@ -411,7 +411,7 @@ public class GroupsController extends AbstractController {
                 groupRepresentation,
                 Map.of(
                         UserModel.USERNAME, user.getUsername(),
-                        UserModel.EMAIL, user.getEmail()
+                        UserModel.EMAIL, user.getEmail() == null ? "" : user.getEmail()
                 )
         );
     }

--- a/src/test/java/fi/metatavu/keycloak/scim/server/test/tests/functional/RealmGroupPatchTestsIT.java
+++ b/src/test/java/fi/metatavu/keycloak/scim/server/test/tests/functional/RealmGroupPatchTestsIT.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.keycloak.events.admin.AdminEvent;
 import org.keycloak.events.admin.OperationType;
 import org.keycloak.events.admin.ResourceType;
+import org.keycloak.representations.idm.UserRepresentation;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.io.IOException;
@@ -205,6 +206,53 @@ public class RealmGroupPatchTestsIT extends AbstractInternalAuthRealmScimTest {
         );
 
         // Clean up
+        deleteRealmUser(TestConsts.TEST_REALM, user.getId());
+        deleteRealmGroup(TestConsts.TEST_REALM, group.getId());
+    }
+
+    /**
+     * Regression: removing a group member whose email is null must not 500.
+     * Map.of() rejects null values, so the admin event dispatch previously
+     * NPE'd when the user had no email set.
+     */
+    @Test
+    void testRemoveGroupMemberWithoutEmail() throws ApiException {
+        ScimClient scimClient = getAuthenticatedScimClient();
+
+        User user = createUser(scimClient, "no-email-user", "No", "Email");
+        Group group = createGroup(scimClient, "no-email-group");
+
+        UserRepresentation userRep = findRealmUser(TestConsts.TEST_REALM, user.getId());
+        userRep.setEmail(null);
+        getKeycloakContainer().getKeycloakAdminClient()
+            .realms()
+            .realm(TestConsts.TEST_REALM)
+            .users()
+            .get(user.getId())
+            .update(userRep);
+
+        PatchRequest addRequest = new PatchRequest();
+        addRequest.setSchemas(List.of("urn:ietf:params:scim:api:messages:2.0:PatchOp"));
+        PatchRequestOperationsInner addOperation = new PatchRequestOperationsInner();
+        addOperation.setOp("add");
+        addOperation.setPath("members");
+        GroupMembersInner member = new GroupMembersInner();
+        member.setValue(user.getId());
+        addOperation.setValue(Collections.singletonList(member));
+        addRequest.setOperations(List.of(addOperation));
+        scimClient.patchGroup(group.getId(), addRequest);
+
+        PatchRequest removeRequest = new PatchRequest();
+        removeRequest.setSchemas(List.of("urn:ietf:params:scim:api:messages:2.0:PatchOp"));
+        PatchRequestOperationsInner removeOperation = new PatchRequestOperationsInner();
+        removeOperation.setOp("remove");
+        removeOperation.setPath("members[value eq \"" + user.getId() + "\"]");
+        removeRequest.setOperations(List.of(removeOperation));
+
+        Group patched = scimClient.patchGroup(group.getId(), removeRequest);
+
+        assertTrue(patched.getMembers() == null || patched.getMembers().isEmpty());
+
         deleteRealmUser(TestConsts.TEST_REALM, user.getId());
         deleteRealmGroup(TestConsts.TEST_REALM, group.getId());
     }


### PR DESCRIPTION
## Summary

- Fixes #103 — `PATCH /Groups` remove-member returned HTTP 500 when the target user had no email set.
- `GroupsController.dispatchGroupMembershipLeaveEvent` passed `user.getEmail()` straight into `Map.of(...)`, which rejects null values and threw `NullPointerException`.
- The sibling `dispatchGroupMembershipJoinEvent` already coalesced null to `""`; this PR applies the same guard to the leave event so the two paths stay symmetric.

## Changes

- `GroupsController.java:414` — `user.getEmail() == null ? "" : user.getEmail()` in the admin event representation map.
- `RealmGroupPatchTestsIT.testRemoveGroupMemberWithoutEmail` — regression test that creates a user, clears their email via the Keycloak admin client, adds them to a group, then removes them via SCIM PATCH and asserts success.

## Test plan

- [ ] `./gradlew test --tests "fi.metatavu.keycloak.scim.server.test.tests.functional.RealmGroupPatchTestsIT"` passes
- [ ] Existing `testRemoveGroupMember` / `testRemoveGroupMemberAdminEvents` still pass
- [ ] Manually verify: PATCH-remove on an email-less user no longer 500s