### PR TITLE
fix: retain omitted name subattributes on PUT /Users

### DIFF
--- a/src/main/java/fi/metatavu/keycloak/scim/server/users/UsersController.java
+++ b/src/main/java/fi/metatavu/keycloak/scim/server/users/UsersController.java
@@ -232,8 +232,12 @@ public class UsersController extends AbstractController {
         ((BooleanUserAttribute) userAttributes.findByScimPath("active")).write(existing, scimUser.getActive() == null || Boolean.TRUE.equals(scimUser.getActive()));
 
         if (scimUser.getName() != null) {
-            ((StringUserAttribute) userAttributes.findByScimPath("name.givenName")).write(existing, scimUser.getName().getGivenName());
-            ((StringUserAttribute) userAttributes.findByScimPath("name.familyName")).write(existing, scimUser.getName().getFamilyName());
+            if (scimUser.getName().getGivenName() != null) {
+                ((StringUserAttribute) userAttributes.findByScimPath("name.givenName")).write(existing, scimUser.getName().getGivenName());
+            }
+            if (scimUser.getName().getFamilyName() != null) {
+                ((StringUserAttribute) userAttributes.findByScimPath("name.familyName")).write(existing, scimUser.getName().getFamilyName());
+            }
         }
 
         if (scimUser.getEmails() != null && !scimUser.getEmails().isEmpty()) {

--- a/src/test/java/fi/metatavu/keycloak/scim/server/test/tests/functional/RealmUserUpdateTestsIT.java
+++ b/src/test/java/fi/metatavu/keycloak/scim/server/test/tests/functional/RealmUserUpdateTestsIT.java
@@ -5,6 +5,7 @@ import fi.metatavu.keycloak.scim.server.test.ScimClient;
 import fi.metatavu.keycloak.scim.server.test.TestConsts;
 import fi.metatavu.keycloak.scim.server.test.client.ApiException;
 import fi.metatavu.keycloak.scim.server.test.client.model.User;
+import fi.metatavu.keycloak.scim.server.test.client.model.UserName;
 import org.junit.jupiter.api.Test;
 import org.keycloak.events.admin.AdminEvent;
 import org.keycloak.events.admin.OperationType;
@@ -182,5 +183,47 @@ public class RealmUserUpdateTestsIT extends AbstractInternalAuthRealmScimTest {
 
         // Cleanup
         deleteRealmUser(TestConsts.TEST_REALM, created.getId());
+    }
+
+    /**
+     * Regression: omitted "name.familyName" in a PUT body must retain the existing value.
+     * Previously the request unconditionally wrote null when the parent "name" object was
+     * present, clearing the existing family name. RFC 7644 §3.5.1 says omitted readWrite
+     * attributes MAY be assumed to be unchanged — applies to subattributes too.
+     */
+    @Test
+    void testReplaceUserRetainsOmittedNameSubattributes() throws ApiException {
+        ScimClient scimClient = getAuthenticatedScimClient();
+
+        User user = new User();
+        user.setUserName("omitted-name-sub");
+        user.setActive(true);
+        user.setSchemas(List.of("urn:ietf:params:scim:schemas:core:2.0:User"));
+        user.setName(getName("Original", "Lastname"));
+        user.setEmails(getEmails("omitted.name.sub@example.com"));
+
+        User created = scimClient.createUser(user);
+        String userId = created.getId();
+
+        // PUT with only givenName under name; familyName omitted
+        User replacement = new User();
+        replacement.setUserName(user.getUserName());
+        replacement.setActive(true);
+        replacement.setSchemas(List.of("urn:ietf:params:scim:schemas:core:2.0:User"));
+        UserName partialName = new UserName();
+        partialName.setGivenName("NewGiven");
+        replacement.setName(partialName);
+
+        User updated = scimClient.updateUser(userId, replacement);
+
+        assertNotNull(updated.getName());
+        assertEquals("NewGiven", updated.getName().getGivenName());
+        assertEquals("Lastname", updated.getName().getFamilyName(), "familyName must be retained when omitted in PUT");
+
+        UserRepresentation realmUser = findRealmUser(TestConsts.TEST_REALM, userId);
+        assertEquals("NewGiven", realmUser.getFirstName());
+        assertEquals("Lastname", realmUser.getLastName());
+
+        deleteRealmUser(TestConsts.TEST_REALM, userId);
     }
 }


### PR DESCRIPTION
## Summary

- Fixes #105 — `PUT /Users/{id}` with a partial `name` object (e.g. only `givenName`) silently cleared the other subattribute (`familyName`), inconsistent with how other omitted readWrite attributes are handled.
- `UsersController.updateUser` now guards each `name.*` write on a non-null subattribute value, matching the existing handling for `emails` and `additionalProperties`.
- Per RFC 7644 §3.5.1: "Attributes whose mutability is 'readWrite' that are omitted from the request body MAY be assumed to be unchanged." That carries over to subattributes.

## Changes

- `UsersController.java:234-241` — only write `name.givenName` / `name.familyName` when the corresponding value is non-null.
- `RealmUserUpdateTestsIT.testReplaceUserRetainsOmittedNameSubattributes` — regression test that creates a user with both `givenName` and `familyName` set, PUTs with only `givenName`, and asserts the existing `familyName` is retained both in the SCIM response and in the underlying Keycloak user.

## Test plan

- [ ] `./gradlew test --tests "fi.metatavu.keycloak.scim.server.test.tests.functional.RealmUserUpdateTestsIT"` passes
- [ ] Existing `testReplaceUser` (full-payload PUT) still passes — partial-name handling does not regress the full-replace case
- [ ] Manually verify a partial-`name` PUT no longer clears the omitted subattribute

## Note on clearing values

This PR makes omitted `name.*` subattributes "no change" rather than "clear", which is the consistent interpretation of the RFC. Clients that need to clear a name subattribute should use PATCH `op: remove` (the normative SCIM way to clear attributes), or send an empty string if the deployment allows it.