### PR TITLE
test: cover ADD members atomicity with mixed valid/unknown IDs

### DIFF
--- a/src/test/java/fi/metatavu/keycloak/scim/server/test/tests/functional/RealmGroupPatchTestsIT.java
+++ b/src/test/java/fi/metatavu/keycloak/scim/server/test/tests/functional/RealmGroupPatchTestsIT.java
@@ -212,6 +212,56 @@ public class RealmGroupPatchTestsIT extends AbstractInternalAuthRealmScimTest {
     }
 
     /**
+     * An ADD members operation that includes one valid and one unknown member ID
+     * must be rejected atomically: HTTP 400 and the valid member must NOT sneak
+     * into the group. Complements the REPLACE / REMOVE atomicity tests below.
+     */
+    @Test
+    void testAddMembersRejectsUnknownIdWithoutMutation() throws ApiException, IOException {
+        ScimClient scimClient = getAuthenticatedScimClient();
+
+        User seeded = createUser(scimClient, "atomic-add-seeded", "Atomic", "Seeded");
+        User candidate = createUser(scimClient, "atomic-add-candidate", "Atomic", "Candidate");
+        Group group = createGroup(scimClient, "atomic-add-group");
+
+        try {
+            // Seed with a known member so we can verify the group is left exactly
+            // as it was (and the candidate did not sneak in).
+            seedGroupWithMember(scimClient, group, seeded);
+
+            // ADD [candidate, unknown] -- must fail atomically with HTTP 400.
+            GroupMembersInner candidateRef = new GroupMembersInner();
+            candidateRef.setValue(candidate.getId());
+            GroupMembersInner unknown = new GroupMembersInner();
+            unknown.setValue("22222222-2222-2222-2222-222222222222");
+            PatchRequest add = new PatchRequest();
+            add.setSchemas(List.of("urn:ietf:params:scim:api:messages:2.0:PatchOp"));
+            PatchRequestOperationsInner addOp = new PatchRequestOperationsInner();
+            addOp.setOp("add");
+            addOp.setPath("members");
+            addOp.setValue(List.of(candidateRef, unknown));
+            add.setOperations(List.of(addOp));
+
+            ApiException ex = assertThrows(ApiException.class,
+                    () -> scimClient.patchGroup(group.getId(), add));
+            assertEquals(400, ex.getCode());
+
+            com.fasterxml.jackson.databind.JsonNode body =
+                    new com.fasterxml.jackson.databind.ObjectMapper().readTree(ex.getResponseBody());
+            assertEquals("400", body.get("status").asText());
+            assertTrue(body.get("detail").asText().contains("22222222-2222-2222-2222-222222222222"),
+                    "detail should name the unknown member id; got: " + body.get("detail").asText());
+
+            // Group must be unchanged: only the seeded member, candidate did NOT sneak in.
+            assertGroupHasOnlyMember(scimClient, group, seeded);
+        } finally {
+            deleteRealmUser(TestConsts.TEST_REALM, candidate.getId());
+            deleteRealmUser(TestConsts.TEST_REALM, seeded.getId());
+            deleteRealmGroup(TestConsts.TEST_REALM, group.getId());
+        }
+    }
+
+    /**
      * A REPLACE operation that includes one valid and one unknown member ID must
      * be rejected atomically: HTTP 400 with an error body naming the bad ID, and
      * the group's original membership must be unchanged.


### PR DESCRIPTION
## Summary

Originally this PR carried the production fix for #107 (`PATCH /Groups` silently 200ing on unknown member IDs, and `replace` wiping membership). That fix has since landed on `develop` via #101 (`Unify group MEMBERS handling, resolve atomically, reject non-String displayName`), which introduced `InvalidGroupMemberReference`, atomic up-front resolution in `GroupsController`, the 400 mapping in `RealmScimServer`, and a broad set of regression tests.

After rebasing onto current `develop`, the production-code portion of this branch is fully redundant. The only remaining gap is an explicit test for the **ADD** case — `#101`'s test suite covers REPLACE (path-based and path-less) and REMOVE atomically, but not ADD.

This PR has been reduced to that one additive test.

## Changes

- `RealmGroupPatchTestsIT.testAddMembersRejectsUnknownIdWithoutMutation` — seeds a group with one known member, sends `ADD members [candidate, unknown]`, asserts:
  - HTTP 400 with a SCIM error body naming the unknown ID
  - the candidate did **not** sneak in (group still has only the originally seeded member)

Mirrors the style of `testReplaceMembersRejectsUnknownIdWithoutMutation` and reuses the existing `seedGroupWithMember` / `assertGroupHasOnlyMember` helpers added in `0cca738`.

## Test plan

- [ ] `./gradlew test --tests "fi.metatavu.keycloak.scim.server.test.tests.functional.RealmGroupPatchTestsIT"` passes

## Related

- Supersedes the production-code changes that were originally in this PR — now provided by #101.
- Closes #107 (final piece of test coverage; underlying behavior already fixed by #101).