### PR TITLE
fix: surface duplicate-username and duplicate-email conflicts on POST /Users

### DIFF
--- a/src/main/java/fi/metatavu/keycloak/scim/server/organization/OrganizationScimServer.java
+++ b/src/main/java/fi/metatavu/keycloak/scim/server/organization/OrganizationScimServer.java
@@ -48,22 +48,16 @@ public abstract class OrganizationScimServer extends AbstractScimServer<Organiza
         KeycloakSession session = scimContext.getSession();
         RealmModel realm = scimContext.getRealm();
 
-        UserModel existingByUsername = session.users().getUserByUsername(realm, createRequest.getUserName());
-        if (existingByUsername != null) {
-            return Response.status(Response.Status.CONFLICT)
-                .entity(String.format("User already exists with username: %s", createRequest.getUserName()))
-                .build();
+        UserModel existing = session.users().getUserByUsername(realm, createRequest.getUserName());
+        if (existing != null) {
+            return ScimErrors.conflict(String.format("User already exists with username: %s", createRequest.getUserName()));
         }
 
         String requestedEmail = createRequest.getEmails() != null && !createRequest.getEmails().isEmpty()
             ? createRequest.getEmails().getFirst().getValue()
             : null;
-        if (requestedEmail != null
-            && !realm.isDuplicateEmailsAllowed()
-            && session.users().getUserByEmail(realm, requestedEmail) != null) {
-            return Response.status(Response.Status.CONFLICT)
-                .entity(String.format("User already exists with email: %s", requestedEmail))
-                .build();
+        if (requestedEmail != null && !realm.isDuplicateEmailsAllowed() && session.users().getUserByEmail(realm, requestedEmail) != null) {
+            return ScimErrors.conflict(String.format("User already exists with email: %s", requestedEmail));
         }
 
         UserAttributes userAttributes = metadataController.getUserAttributes(scimContext);

--- a/src/main/java/fi/metatavu/keycloak/scim/server/organization/OrganizationScimServer.java
+++ b/src/main/java/fi/metatavu/keycloak/scim/server/organization/OrganizationScimServer.java
@@ -44,6 +44,27 @@ public abstract class OrganizationScimServer extends AbstractScimServer<Organiza
             return Response.status(Response.Status.BAD_REQUEST).entity("Invalid email format for userName").build();
         }
 
+        KeycloakSession session = scimContext.getSession();
+        RealmModel realm = scimContext.getRealm();
+
+        UserModel existingByUsername = session.users().getUserByUsername(realm, createRequest.getUserName());
+        if (existingByUsername != null) {
+            return Response.status(Response.Status.CONFLICT)
+                .entity(String.format("User already exists with username: %s", createRequest.getUserName()))
+                .build();
+        }
+
+        String requestedEmail = createRequest.getEmails() != null && !createRequest.getEmails().isEmpty()
+            ? createRequest.getEmails().getFirst().getValue()
+            : null;
+        if (requestedEmail != null
+            && !realm.isDuplicateEmailsAllowed()
+            && session.users().getUserByEmail(realm, requestedEmail) != null) {
+            return Response.status(Response.Status.CONFLICT)
+                .entity(String.format("User already exists with email: %s", requestedEmail))
+                .build();
+        }
+
         UserAttributes userAttributes = metadataController.getUserAttributes(scimContext);
 
         User user = organizationUserController.createOrganizationUser(

--- a/src/main/java/fi/metatavu/keycloak/scim/server/realm/RealmScimServer.java
+++ b/src/main/java/fi/metatavu/keycloak/scim/server/realm/RealmScimServer.java
@@ -42,7 +42,20 @@ public class RealmScimServer extends AbstractScimServer<RealmScimContext> {
 
         UserModel existing = session.users().getUserByUsername(realm, createRequest.getUserName());
         if (existing != null) {
-            return Response.status(Response.Status.CONFLICT).entity("User already exists").build();
+            return Response.status(Response.Status.CONFLICT)
+                .entity(String.format("User already exists with username: %s", createRequest.getUserName()))
+                .build();
+        }
+
+        String requestedEmail = createRequest.getEmails() != null && !createRequest.getEmails().isEmpty()
+            ? createRequest.getEmails().getFirst().getValue()
+            : null;
+        if (requestedEmail != null
+            && !realm.isDuplicateEmailsAllowed()
+            && session.users().getUserByEmail(realm, requestedEmail) != null) {
+            return Response.status(Response.Status.CONFLICT)
+                .entity(String.format("User already exists with email: %s", requestedEmail))
+                .build();
         }
 
         UserAttributes userAttributes = metadataController.getUserAttributes(scimContext);

--- a/src/test/java/fi/metatavu/keycloak/scim/server/test/tests/functional/OrganizationUserCreateTestsIT.java
+++ b/src/test/java/fi/metatavu/keycloak/scim/server/test/tests/functional/OrganizationUserCreateTestsIT.java
@@ -118,14 +118,50 @@ public class OrganizationUserCreateTestsIT extends AbstractOrganizationScimTest 
         User created = scimClient.createUser(user);
         assertNotNull(created);
 
-        // Second creation should fail with 409 Conflict
+        // Second creation should fail with 409 Conflict and identify the duplicated field
         ApiException exception = assertThrows(ApiException.class, () ->
             scimClient.createUser(user)
         );
 
         assertEquals(409, exception.getCode());
+        assertTrue(exception.getMessage().contains("username"),
+            "Expected conflict message to mention 'username'; got: " + exception.getMessage());
+        assertTrue(exception.getMessage().contains("dupe-user"),
+            "Expected conflict message to include the offending username; got: " + exception.getMessage());
 
         // Clean up
+        deleteRealmUser(TestConsts.ORGANIZATIONS_REALM, created.getId());
+    }
+
+    @Test
+    void testCreateDuplicateEmailReturnsConflict() throws ApiException {
+        ScimClient scimClient = getAuthenticatedScimClient(TestConsts.ORGANIZATION_1_ID);
+
+        User first = new User();
+        first.setUserName("org-dupe-email-first");
+        first.setActive(true);
+        first.setSchemas(List.of("urn:ietf:params:scim:schemas:core:2.0:User"));
+        first.setEmails(getEmails("org.dupe.email@example.com"));
+
+        User created = scimClient.createUser(first);
+        assertNotNull(created);
+
+        User second = new User();
+        second.setUserName("org-dupe-email-second");
+        second.setActive(true);
+        second.setSchemas(List.of("urn:ietf:params:scim:schemas:core:2.0:User"));
+        second.setEmails(getEmails("org.dupe.email@example.com"));
+
+        ApiException exception = assertThrows(ApiException.class, () ->
+            scimClient.createUser(second)
+        );
+
+        assertEquals(409, exception.getCode());
+        assertTrue(exception.getMessage().contains("email"),
+            "Expected conflict message to mention 'email'; got: " + exception.getMessage());
+        assertTrue(exception.getMessage().contains("org.dupe.email@example.com"),
+            "Expected conflict message to include the offending email; got: " + exception.getMessage());
+
         deleteRealmUser(TestConsts.ORGANIZATIONS_REALM, created.getId());
     }
 

--- a/src/test/java/fi/metatavu/keycloak/scim/server/test/tests/functional/RealmUserCreateTestsIT.java
+++ b/src/test/java/fi/metatavu/keycloak/scim/server/test/tests/functional/RealmUserCreateTestsIT.java
@@ -112,14 +112,50 @@ public class RealmUserCreateTestsIT extends AbstractInternalAuthRealmScimTest {
         User created = scimClient.createUser(user);
         assertNotNull(created);
 
-        // Second creation should fail with 409 Conflict
+        // Second creation should fail with 409 Conflict and identify the duplicated field
         ApiException exception = assertThrows(ApiException.class, () ->
             scimClient.createUser(user)
         );
 
         assertEquals(409, exception.getCode());
+        assertTrue(exception.getMessage().contains("username"),
+            "Expected conflict message to mention 'username'; got: " + exception.getMessage());
+        assertTrue(exception.getMessage().contains("dupe-user"),
+            "Expected conflict message to include the offending username; got: " + exception.getMessage());
 
         // Clean up
+        deleteRealmUser(TestConsts.TEST_REALM, created.getId());
+    }
+
+    @Test
+    void testCreateDuplicateEmailReturnsConflict() throws ApiException {
+        ScimClient scimClient = getAuthenticatedScimClient();
+
+        User first = new User();
+        first.setUserName("dupe-email-first");
+        first.setActive(true);
+        first.setSchemas(List.of("urn:ietf:params:scim:schemas:core:2.0:User"));
+        first.setEmails(getEmails("dupe.email@example.com"));
+
+        User created = scimClient.createUser(first);
+        assertNotNull(created);
+
+        User second = new User();
+        second.setUserName("dupe-email-second");
+        second.setActive(true);
+        second.setSchemas(List.of("urn:ietf:params:scim:schemas:core:2.0:User"));
+        second.setEmails(getEmails("dupe.email@example.com"));
+
+        ApiException exception = assertThrows(ApiException.class, () ->
+            scimClient.createUser(second)
+        );
+
+        assertEquals(409, exception.getCode());
+        assertTrue(exception.getMessage().contains("email"),
+            "Expected conflict message to mention 'email'; got: " + exception.getMessage());
+        assertTrue(exception.getMessage().contains("dupe.email@example.com"),
+            "Expected conflict message to include the offending email; got: " + exception.getMessage());
+
         deleteRealmUser(TestConsts.TEST_REALM, created.getId());
     }
 

--- a/src/test/java/fi/metatavu/keycloak/scim/server/test/tests/functional/RealmUserCreateTestsIT.java
+++ b/src/test/java/fi/metatavu/keycloak/scim/server/test/tests/functional/RealmUserCreateTestsIT.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 /**


### PR DESCRIPTION
## Summary

- Fixes #109 — `POST /Users` returned `{\"error\":\"unknown_error\"}` for duplicate-email collisions (no SCIM-layer pre-check; Keycloak's generic error handler surfaced the model exception). The realm-scope's existing duplicate-username message also didn't identify which field collided. The organization-scope had no pre-check at all.
- Adds a `getUserByUsername` + `getUserByEmail` pre-check on both scopes. The 409 body now identifies the duplicated field and value: `User already exists with username: <X>` / `User already exists with email: <X>`.
- The email pre-check is gated on `RealmModel.isDuplicateEmailsAllowed()` so realms configured to allow duplicate emails still create successfully.

## Changes

- `RealmScimServer.createUser` — distinct message on the existing username conflict, plus a new email pre-check gated on the realm flag.
- `OrganizationScimServer.createUser` — adds both pre-checks symmetric to the realm scope (previously had neither).
- `RealmUserCreateTestsIT` — `testCreateDuplicateUserReturnsConflict` strengthened to assert the message names `username` and the offending value; new `testCreateDuplicateEmailReturnsConflict`.
- `OrganizationUserCreateTestsIT` — same upgrade and new email test on the org scope.

## Test plan

- [ ] `./gradlew test --tests \"fi.metatavu.keycloak.scim.server.test.tests.functional.RealmUserCreateTestsIT\"` passes
- [ ] `./gradlew test --tests \"fi.metatavu.keycloak.scim.server.test.tests.functional.OrganizationUserCreateTestsIT\"` passes
- [ ] Manually verify a duplicate-email POST on a realm with **Allow Duplicate Emails** disabled returns 409 with the new message instead of `unknown_error`
- [ ] Manually verify the same POST on a realm with **Allow Duplicate Emails** enabled still creates the user successfully

## Notes / follow-ups

- Keycloak's user-profile email validator can still enforce uniqueness independently of the realm-level Allow Duplicate Emails flag. In that mode the pre-check is bypassed but `setEmail` will throw `ModelDuplicateException`, which still surfaces as `unknown_error`. Catching that exception in the controller layer is intentionally out of scope here — happy to follow up if you'd like it bundled.
- Once #101 lands and `ScimErrors` becomes the canonical SCIM error builder, these two `Response.status(...).entity(...).build()` calls should migrate to `ScimErrors.conflict(...)`. Trivial follow-up.