### PR TITLE
fix: set sslRequired=NONE on test realm fixtures

### DIFF
--- a/src/test/resources/kc-external.json
+++ b/src/test/resources/kc-external.json
@@ -26,7 +26,7 @@
   "oauth2DeviceCodeLifespan" : 600,
   "oauth2DevicePollingInterval" : 5,
   "enabled" : true,
-  "sslRequired" : "external",
+  "sslRequired" : "NONE",
   "registrationAllowed" : false,
   "registrationEmailAsUsername" : false,
   "rememberMe" : false,

--- a/src/test/resources/kc-organizations.json
+++ b/src/test/resources/kc-organizations.json
@@ -28,7 +28,7 @@
   "oauth2DeviceCodeLifespan" : 600,
   "oauth2DevicePollingInterval" : 5,
   "enabled" : true,
-  "sslRequired" : "external",
+  "sslRequired" : "NONE",
   "registrationAllowed" : false,
   "registrationEmailAsUsername" : false,
   "rememberMe" : false,

--- a/src/test/resources/kc-test.json
+++ b/src/test/resources/kc-test.json
@@ -26,7 +26,7 @@
   "oauth2DeviceCodeLifespan" : 600,
   "oauth2DevicePollingInterval" : 5,
   "enabled" : true,
-  "sslRequired" : "external",
+  "sslRequired" : "NONE",
   "registrationAllowed" : false,
   "registrationEmailAsUsername" : false,
   "rememberMe" : false,


### PR DESCRIPTION
## Summary

Change `"sslRequired": "external"` to `"sslRequired": "NONE"` on the three test realm fixtures (`kc-test.json`, `kc-organizations.json`, `kc-external.json`) so the functional IT suite can be run locally on macOS / Docker Desktop.

## Why

Keycloak's `sslRequired=external` setting enforces HTTPS unless the request originates from a loopback or RFC 1918 private IP. The three realm imports we ship for tests all carry that setting.

| Environment | Source IP Keycloak observes | Result |
|---|---|---|
| Linux Docker (GitHub Actions, `run-tests`) | `127.0.0.1` (kernel DNAT preserves loopback) | `external` accepts → 200 |
| Docker Desktop on macOS | `172.65.x.x` (userspace proxy in the Docker VM — outside RFC 1918, since private `172.x` is only `172.16-31`) | `external` rejects every plain-HTTP request with `403 HTTPS required` |

On macOS this results in every IT extending `AbstractRealmScimTest` or `AbstractOrganizationScimTest` failing at `getServiceAccountToken()` with `jakarta.ws.rs.ForbiddenException: HTTP 403 Forbidden`, before the test method runs. CI is unaffected because `NONE` is strictly more permissive than `external` and the CI source IP was already in the loopback range that `external` already accepted.

These are test fixtures and never need real HTTPS, so `NONE` is the correct setting.

## Verification

Reproduced and confirmed with a bare `quay.io/keycloak/keycloak:26.3.5` container (no providers, no test harness) using each realm fixture. Quarkus access log shows `remote=172.65.251.78` on every host request, and the response is `403 {"error":"invalid_request","error_description":"HTTPS required"}` on `/realms/test/.well-known/openid-configuration` and the token endpoint. Patching `sslRequired` to `NONE` and reimporting returns `200` + valid JWT for the `client_credentials` grant.

End-to-end: with the fix applied together with the Testcontainers 1.21.4 bump (PR #118, required separately so containers can start on Docker Desktop 29+), `./gradlew test --tests "*RealmSchemasTestsIT"` now passes locally on Docker Desktop 4.67.0 / Engine 29.3.1 / JDK 21 where previously every test in that class failed at admin token grant.

## Test plan

- [ ] CI `run-tests` passes against this branch
- [ ] Maintainers can run the IT suite locally on macOS without the `HTTPS required` 403s (combine with #118)