### PR TITLE
Fix PATCH /Users rejecting requests that omit unchanged mandatory fields

### DIFF
--- a/src/main/java/fi/metatavu/keycloak/scim/server/metadata/UserAttributes.java
+++ b/src/main/java/fi/metatavu/keycloak/scim/server/metadata/UserAttributes.java
@@ -33,6 +33,15 @@ public class UserAttributes {
     }
 
     /**
+     * Returns all configured user attributes.
+     *
+     * @return all user attributes
+     */
+    public List<UserAttribute<?>> list() {
+        return List.copyOf(attributeMap.values());
+    }
+
+    /**
      * Lists user attributes by source
      *
      * @param source source

--- a/src/main/java/fi/metatavu/keycloak/scim/server/users/UserProfileValidationService.java
+++ b/src/main/java/fi/metatavu/keycloak/scim/server/users/UserProfileValidationService.java
@@ -74,10 +74,18 @@ public final class UserProfileValidationService {
 
     /**
      * Validates patched attributes before applying them to the existing user.
+     * <p>
+     * RFC 7644 §3.5.2 PATCH is a partial update — fields absent from the request
+     * keep their current value. The Keycloak user profile validator runs against
+     * the attribute map it is given, so we pre-merge the existing user's current
+     * attribute values with the patch delta. REMOVE operations come through with
+     * a null value and overwrite the existing entry, so required-field checks
+     * still reject removing a mandatory field.
      *
      * @param session Keycloak session
+     * @param userAttributes user attribute metadata
      * @param existing existing user
-     * @param patchedAttributes patched user profile attributes
+     * @param patchedAttributes patched user profile attributes (delta only)
      * @throws UserProfileValidationException when validation fails
      */
     public static void validateForPatch(
@@ -87,10 +95,24 @@ public final class UserProfileValidationService {
         Map<String, ?> patchedAttributes
     ) throws UserProfileValidationException {
         try {
-            validate(session, new HashMap<>(patchedAttributes), existing);
+            Map<String, Object> merged = readExistingAttributes(userAttributes, existing);
+            merged.putAll(patchedAttributes);
+            validate(session, merged, existing);
         } catch (UserProfileValidationException e) {
             throw remapToScimPaths(e, userAttributes);
         }
+    }
+
+    private static Map<String, Object> readExistingAttributes(UserAttributes userAttributes, UserModel existing) {
+        Map<String, Object> result = new HashMap<>();
+        for (UserAttribute<?> attribute : userAttributes.list()) {
+            Object value = attribute.read(existing);
+            if (value == null) {
+                continue;
+            }
+            result.putIfAbsent(attribute.getSourceId(), normalizeValue(value));
+        }
+        return result;
     }
 
     private static void validate(KeycloakSession session, Map<String, ?> attributes) throws UserProfileValidationException {

--- a/src/test/java/fi/metatavu/keycloak/scim/server/test/tests/functional/RealmUserPatchValidationTestsIT.java
+++ b/src/test/java/fi/metatavu/keycloak/scim/server/test/tests/functional/RealmUserPatchValidationTestsIT.java
@@ -1,0 +1,111 @@
+package fi.metatavu.keycloak.scim.server.test.tests.functional;
+
+import fi.metatavu.keycloak.scim.server.test.ScimClient;
+import fi.metatavu.keycloak.scim.server.test.TestConsts;
+import fi.metatavu.keycloak.scim.server.test.client.ApiException;
+import fi.metatavu.keycloak.scim.server.test.client.model.PatchRequest;
+import fi.metatavu.keycloak.scim.server.test.client.model.PatchRequestOperationsInner;
+import fi.metatavu.keycloak.scim.server.test.client.model.User;
+import fi.metatavu.keycloak.scim.server.test.client.model.UserEmailsInner;
+import fi.metatavu.keycloak.scim.server.test.client.model.UserName;
+import fi.metatavu.keycloak.scim.server.test.tests.AbstractValidationRealmScimTest;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression tests for issue #123: PATCH /Users must not require mandatory
+ * fields that are already set on the existing user (RFC 7644 §3.5.2 — PATCH
+ * is a partial update; validators must see the post-merge state).
+ */
+@Testcontainers
+public class RealmUserPatchValidationTestsIT extends AbstractValidationRealmScimTest {
+
+    @Test
+    void testPatchOnlyActiveDoesNotRequireMandatoryFields() throws ApiException {
+        ScimClient scimClient = getAuthenticatedScimClient();
+
+        // Validation realm marks firstName, lastName and email as required (roles: user).
+        User user = createValidUser("patch-active-only");
+        User created = scimClient.createUser(user);
+        assertNotNull(created);
+        assertTrue(created.getActive());
+
+        try {
+            // PATCH a single non-required attribute. The required fields are
+            // already set on the existing user, so validation must pass.
+            User patched = scimClient.patchUser(created.getId(), new PatchRequest()
+                .schemas(List.of("urn:ietf:params:scim:api:messages:2.0:PatchOp"))
+                .operations(List.of(
+                    new PatchRequestOperationsInner()
+                        .op("replace")
+                        .path("active")
+                        .value(Boolean.FALSE)
+                )));
+
+            assertNotNull(patched);
+            assertFalse(patched.getActive());
+        } finally {
+            deleteRealmUser(TestConsts.TEST_REALM, created.getId());
+        }
+    }
+
+    @Test
+    void testPatchReplaceMandatoryFieldKeepsOtherMandatoryFields() throws ApiException {
+        ScimClient scimClient = getAuthenticatedScimClient();
+
+        User user = createValidUser("patch-replace-family");
+        User created = scimClient.createUser(user);
+        assertNotNull(created);
+
+        try {
+            // Mirrors the payload from issue #123: replace one required field
+            // while leaving the others untouched in the PATCH body.
+            User patched = scimClient.patchUser(created.getId(), new PatchRequest()
+                .schemas(List.of("urn:ietf:params:scim:api:messages:2.0:PatchOp"))
+                .operations(List.of(
+                    new PatchRequestOperationsInner()
+                        .op("replace")
+                        .path("active")
+                        .value(Boolean.FALSE),
+                    new PatchRequestOperationsInner()
+                        .op("replace")
+                        .path("name.familyName")
+                        .value("NEW_FAMILY_NAME")
+                )));
+
+            assertNotNull(patched);
+            assertFalse(patched.getActive());
+            assertNotNull(patched.getName());
+            assertEquals("NEW_FAMILY_NAME", patched.getName().getFamilyName());
+            assertEquals("Given", patched.getName().getGivenName());
+        } finally {
+            deleteRealmUser(TestConsts.TEST_REALM, created.getId());
+        }
+    }
+
+    private User createValidUser(String userName) {
+        User user = new User();
+        user.setUserName(userName);
+        user.setActive(true);
+        user.setSchemas(List.of("urn:ietf:params:scim:schemas:core:2.0:User"));
+
+        UserName name = new UserName();
+        name.setGivenName("Given");
+        name.setFamilyName("Family");
+        user.setName(name);
+
+        UserEmailsInner email = new UserEmailsInner();
+        email.setValue(userName + "@example.com");
+        email.setPrimary(true);
+        user.setEmails(List.of(email));
+
+        return user;
+    }
+}


### PR DESCRIPTION
## Summary

PATCH /Users currently rejects requests that don't include every mandatory user-profile field, even when the user already has those fields set. This violates RFC 7644 §3.5.2 (PATCH is a partial update — absent attributes keep their current value) and makes it impossible to update non-mandatory fields once a profile config marks anything as required.

This change makes the user-profile validator run against the post-merge state (existing user + patch delta), so unchanged mandatory fields no longer trip required-field validation.

Fixes #123.

## What Changed

- **`UserProfileValidationService.validateForPatch`**: now reads the existing user's attribute values via `UserAttributes`, overlays the patch delta on top, and validates the merged map. The patch delta still wins for REPLACE/ADD; REMOVE overlays null so a required field can't be silently removed.
- **`UserAttributes.list()`**: new helper that returns all configured attributes (used by the merge step). Existing `findByScimPath` / `listBySource` / `findBySourceId` are unchanged.
- **Tests**: new `RealmUserPatchValidationTestsIT` in the validation realm covers (1) PATCH of a non-required attribute when mandatory fields are present on the user and (2) PATCH replacing one mandatory field while leaving others untouched. Both fail before the fix and pass after.

## Reviewer Guide

- **Start here**: `UserProfileValidationService.java` lines 83–105 — the new validateForPatch + `readExistingAttributes`.
- **Design decision**: pre-merge the validator input instead of relying on Keycloak's `DefaultAttributes` fallback to `existing.getAttribute(name)`. The fallback exists but has been observed not to fire reliably for required-field validation on USER_API context; merging up-front makes correctness explicit and version-independent. Behavior on REMOVE is unchanged — the delta still writes null and overrides the existing value, so required-field checks still reject removing a mandatory field.
- **Pay attention to**: `readExistingAttributes` walks every configured attribute — USER_MODEL, USER_PROFILE and IDP_MAPPER. IDP-mapper attributes are unmanaged from the profile validator's perspective; including their current value is harmless because the validator only checks attributes that appear in the profile config.

## Testing Plan

### Happy Path
- [ ] In a realm where the user profile marks fields as required (e.g. `firstName`, `lastName`, `email`), create a SCIM user that has all required fields populated.
- [ ] PATCH that user with a single non-required operation (e.g. `replace active=false`) — expect HTTP 200 and the change applied.
- [ ] PATCH that user with `replace name.familyName=X` only — expect HTTP 200, family name updated, given name preserved.

### Edge Cases
- [ ] PATCH with `op=remove` on a required field — expect HTTP 400 (REMOVE intentionally overlays null, so required validation still fires).
- [ ] PATCH with the path-less Okta shape (`{"op":"replace","value":{"active":false}}`) on a user with required fields set — expect HTTP 200.
- [ ] PATCH creating an invalid value for a required field (e.g. `replace userName="ab"` when min length is 3) — expect HTTP 400, with the delta value validated.
- [ ] PATCH on the organization-scoped endpoint (`/scim/v2/organizations/{id}/Users/{id}`) — same behavior since both endpoints share `UserProfileValidationService`.

### Regression Checks
- [ ] Existing PATCH tests (`RealmUserPatchTestsIT`, `OrganizationUserPatchTestsIT`) still pass.
- [ ] User create / update validation (`RealmUserValidationTestsIT`, `OrganizationUserValidationTestsIT`) still rejects invalid input.
- [ ] User CRUD tests (`*UserCreateTestsIT`, `*UserUpdateTestsIT`, `*UserListTestsIT`, `*UserFindTestsIT`, `*UserDeleteTestsIT`) still pass.